### PR TITLE
feat(api): Implement Axios interceptor for JWT token refresh

### DIFF
--- a/src/api/apiService.ts
+++ b/src/api/apiService.ts
@@ -1,8 +1,9 @@
-import axios, { AxiosResponse } from 'axios';
+import { SearchEndpoints, UsersEndpoints, WorkflowsEndpoints } from '@/api/endpoints';
+import type { FailedRequestQueueItem, ProcessQueueItem } from '@/interfaces/api';
+import type { WorkflowState } from '@/interfaces/search';
 import { SearchAssistant, SearchResult } from '@/interfaces/search';
 import type { LoginResponse } from '@/interfaces/user';
-import type { WorkflowState } from '@/interfaces/search'
-import { SearchEndpoints, UsersEndpoints, WorkflowsEndpoints } from '@/api/endpoints';
+import axios, { AxiosResponse } from 'axios';
 
 const apiClient = axios.create({
   // **Crucial for JWT Cookie Auth**
@@ -12,6 +13,85 @@ const apiClient = axios.create({
     'Content-Type': 'application/json',
   },
 });
+
+let isRefreshing = false; // Flag to prevent multiple simultaneous refresh calls
+let failedQueue: FailedRequestQueueItem[] = [];   // Queue for failed requests
+
+// Helper function to process the queue of failed requests
+const processQueue = (error: Error | null, token: string | null = null): void => {
+  (failedQueue as ProcessQueueItem[]).forEach(prom => {
+    if (error) {
+      prom.reject(error);
+    } else {
+      prom.resolve(token as string);
+    }
+  });
+  failedQueue = [];
+};
+
+apiClient.interceptors.response.use(
+  (response) => {
+    // If the response is successful, just return it
+    return response;
+  },
+  async (error) => {
+    const originalRequest = error.config;
+
+    // Check if the error is 401 and the request hasn't been retried yet
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      // Mark the original request for retry
+      originalRequest._retry = true;
+
+      // If a refresh is already in progress, queue the request
+      if (isRefreshing) {
+        return new Promise(function(resolve, reject) {
+          failedQueue.push({ resolve, reject });
+        })
+        .then(() => {
+          // Re-issue the original request (it will now carry the new cookie)
+          return apiClient(originalRequest);
+        })
+        .catch(err => {
+          return Promise.reject(err);
+        });
+      }
+
+      // 🚨 Start the token refresh process
+      isRefreshing = true;
+
+      try {
+        // Send a request to the server's refresh endpoint.
+        // The HTTP-only Refresh Token cookie is sent automatically.
+        const response = await axios.post(UsersEndpoints.refreshToken.create(), null, {
+          withCredentials: true,
+        });
+
+        // Backend should respond with 200 and set new HTTP-only cookies
+        // (New Access Token and optionally a new Refresh Token)
+
+        isRefreshing = false;
+        processQueue(null); // Process all queued requests
+
+        // Re-issue the original request with the new Access Token cookie
+        return apiClient(originalRequest);
+
+      } catch (refreshError) {
+        isRefreshing = false;
+        processQueue(refreshError as Error); // Reject all queued requests
+
+        // Log out the user or redirect to the login page
+        // You would typically use a Vue Router/State/Pinia action here
+        console.error("Token refresh failed. Redirecting to login.");
+        // Example: router.push('/login');
+
+        return Promise.reject(refreshError);
+      }
+    }
+
+    // For all other errors (400, 403, 500, etc.), reject the promise
+    return Promise.reject(error);
+  }
+);
 
 export const apiService = {
   search: {

--- a/src/api/endpoints/index.ts
+++ b/src/api/endpoints/index.ts
@@ -17,7 +17,11 @@ export const UsersEndpoints = {
   login: {
     create: () =>
       `${AURAFLUX_NEXUS_URL}/users/login/`,
-  }
+  },
+  refreshToken: {
+    create: () =>
+      `${AURAFLUX_NEXUS_URL}/users/token/refresh/`,
+  },
 }
 
 export const WorkflowsEndpoints = {

--- a/src/interfaces/api.ts
+++ b/src/interfaces/api.ts
@@ -1,0 +1,9 @@
+export interface FailedRequestQueueItem {
+  resolve: (value?: any) => void;
+  reject: (error?: any) => void;
+}
+
+export interface ProcessQueueItem {
+  resolve: (value?: string) => void;
+  reject: (error?: Error) => void;
+}


### PR DESCRIPTION
Introduce an Axios response interceptor to automatically handle expired JWT Access Tokens by refreshing them using the HttpOnly Refresh Token cookie.

Key changes:
- Defined `FailedRequestQueueItem` and `ProcessQueueItem` interfaces.
- Implemented an Axios response interceptor that checks for HTTP 401 status codes.
- Added logic to prevent concurrent refresh calls (`isRefreshing` flag).
- Implemented a queue (`failedQueue`) to hold and retry original requests after a successful token refresh, ensuring zero user-facing disruption.
- Defined `UsersEndpoints.refreshToken` for the new backend endpoint.
- If the token refresh fails, all queued requests are rejected, and the application is signaled to redirect the user to log in.

This ensures seamless session maintenance for the user when the short-lived Access Token expires.