### PR TITLE
refactor(auth): Implement robust JWT cookie authentication flow

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,6 @@ const authStore = useAuthStore();
 
 onMounted(() => {
   // 1. Check for valid JWT cookie on initial load
-  // authStore.checkAuthStatus();
+  authStore.checkAuthStatus();
 });
 </script>

--- a/src/api/apiService.ts
+++ b/src/api/apiService.ts
@@ -2,7 +2,7 @@ import { SearchEndpoints, UsersEndpoints, WorkflowsEndpoints } from '@/api/endpo
 import type { FailedRequestQueueItem, ProcessQueueItem } from '@/interfaces/api';
 import type { Dichotomy, LockDataResponse, WorkflowState } from '@/interfaces/search';
 import { SearchAssistant, SearchResult } from '@/interfaces/search';
-import type { LoginResponse } from '@/interfaces/user';
+import type { User } from '@/interfaces/user';
 import axios, { AxiosResponse } from 'axios';
 
 const apiClient = axios.create({
@@ -107,8 +107,13 @@ export const apiService = {
     }
   },
   users: {
+    check: {
+      get: (): Promise<AxiosResponse<User>> => {
+        return apiClient.get(UsersEndpoints.check.get());
+      }
+    },
     login: {
-      create: (username: string, password: string): Promise<AxiosResponse<LoginResponse>> => {
+      create: (username: string, password: string): Promise<AxiosResponse<User>> => {
         return apiClient.post(UsersEndpoints.login.create(), {username: username, password: password});
       },
     },

--- a/src/api/endpoints/index.ts
+++ b/src/api/endpoints/index.ts
@@ -14,6 +14,10 @@ export const SearchEndpoints = {
 };
 
 export const UsersEndpoints = {
+  check: {
+    get: () =>
+      `${AURAFLUX_NEXUS_URL}/users/status/`,
+  },
   login: {
     create: () =>
       `${AURAFLUX_NEXUS_URL}/users/login/`,

--- a/src/components/organisms/ScopeSelector.vue
+++ b/src/components/organisms/ScopeSelector.vue
@@ -200,7 +200,7 @@ const selectedDichotomy = computed(() => {
             roles: rolesArray,
         } as Dichotomy;
     }
-    return dynamicDichotomies.value.find(d => d.id === selectedDichotomyId.value) || null;
+    return dynamicDichotomies.value.find(d => d.name === selectedDichotomyId.value) || null;
 });
 
 const manualDichotomyValidation = computed(() => {

--- a/src/interfaces/user.ts
+++ b/src/interfaces/user.ts
@@ -1,9 +1,6 @@
-export interface LoginResponse {
-    message: string;
-    username: string;
-}
-
 export interface User {
+  id: number;
   username: string;
+  email: string;
   // Add any other necessary user fields here (e.g., email, roles)
 }

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -28,21 +28,11 @@ export const useAuthStore = defineStore('auth', () => {
       // If the request succeeds (status 200) because the JWT cookie is valid, the user is authenticated.
 
       // MOCK: Simulate an initial check that finds a valid user
-      const response = await fetch('/api/fetch-state', { method: 'GET' });
+      const response = await apiService.users.check.get();
+      let user_info: User = response.data;
 
-      if (response.ok) {
-        // Assume successful response means user is authenticated and we get basic user info
-        // (In a real app, you might have a dedicated /api/me endpoint)
-        const stateData = await response.json();
-
-        // MOCK USER DATA based on successful cookie authentication
-        user.value = {
-            username: 'demo_user',
-        };
-
-        // Note: The workflow data (stateData) is then handled by the WorkflowStore,
-        // but this action confirms authentication.
-
+      if (user_info) {
+        user.value = user_info;
       } else {
         // 401 Unauthorized or other error means the user is not logged in or the token expired
         user.value = null;
@@ -63,18 +53,15 @@ export const useAuthStore = defineStore('auth', () => {
     try {
       // 1. Call POST /api/login endpoint
       const response = await apiService.users.login.create(username, password);
-      // 2. Tokens are set as HttpOnly cookies (handled by the browser)
-      const data = await response.data;
+      let user_info = response.data;
 
-      if (data) {
+      if (user_info) {
         // 3. Update local user state
-        user.value = {
-            username: data.username,
-        };
+        user.value = user_info;
         return true;
       } else {
         // Handle failed login (e.g., invalid credentials)
-        throw new Error(response.data.message || 'Login failed.');
+        throw new Error('Login failed.');
       }
     } catch (error) {
       user.value = null;


### PR DESCRIPTION
Update the frontend authentication logic to fully utilize the new `/users/status/` endpoint and standardize user data payloads.

- **Check Status Implementation:** Replaced the mock fetch in `authStore.checkAuthStatus()` with a call to the new `apiService.users.check.get()`, which hits the secure `/users/status/` endpoint to validate the JWT cookie and fetch user data.
- **Payload Standardization:**
    - Removed `LoginResponse` interface.
    - Updated `apiService.users.login.create` to return the full `User` object (`User` interface) instead of a simple message/username pair.
- **Component Activation:** Uncommented the call to `authStore.checkAuthStatus()` in `App.vue` to enable initial session check on application load.
- **UI Fix:** Updated `ScopeSelector.vue` to correctly use `d.name` as the identifier for finding the selected dichotomy, aligning with the backend data structure change.