### PR TITLE
fix(exploration): update scope API path and refactor interfaces

### DIFF
--- a/src/components/organisms/ScopeRefinementForm.vue
+++ b/src/components/organisms/ScopeRefinementForm.vue
@@ -225,7 +225,7 @@ async function handleUnifiedSubmit(targetStatus: EntityStatus) {
     // API Call (Simulated/Corrected based on expected Scope endpoint)
     let response = null;
     if (scopeElementId.value) {
-      response = await apiService.workflows.scopes.update(scopeElementId.value, props.initialScopeElement.label, value, finalStatus);
+      response = await apiService.knowledge.scopes.update(scopeElementId.value, props.initialScopeElement.label, value, finalStatus);
     }
     else {
       response = await apiService.workflows.scopes.create(props.initialScopeElement.label, value, finalStatus);

--- a/src/components/pages/ExplorationPage.vue
+++ b/src/components/pages/ExplorationPage.vue
@@ -122,14 +122,14 @@ import { computed, onMounted, ref } from 'vue';
 import ActionBar from '@/components/molecules/ActionBar.vue';
 import ProgressTracker from '@/components/molecules/ProgressTracker.vue';
 import TabbedPanel from '@/components/molecules/TabbedPanel.vue';
-import ThreePaneWorkspaceTemplate from '@/components/templates/ThreePaneWorkspaceTemplate.vue';
 import FullScreenModalTemplate from '@/components/templates/FullScreenModalTemplate.vue';
+import ThreePaneWorkspaceTemplate from '@/components/templates/ThreePaneWorkspaceTemplate.vue';
 
 // --- Workspace Organisms ---
 import ChatInterface from '@/components/organisms/ChatInterface.vue';
 import ConceptualMapCanvas from '@/components/organisms/ConceptualMapCanvas.vue';
-import ResourceRepository from '@/components/organisms/ResourceRepository.vue';
 import ReflectionLogForm from '@/components/organisms/ReflectionLogForm.vue';
+import ResourceRepository from '@/components/organisms/ResourceRepository.vue';
 
 // --- Custom Sidebar & Modal Components (NEW) ---
 import CanvasStructureSidebar from '@/components/templates/CanvasStructureSidebar.vue'; // NEW: For multi-canvas management (U.S. 2, 12)
@@ -137,8 +137,10 @@ import CanvasStructureSidebar from '@/components/templates/CanvasStructureSideba
 // import ResourceAddItemModal from '@/components/organisms/ResourceAddItemModal.vue'; // NEW: For manual resource entry (U.S. 5)
 
 // --- Interfaces ---
+import type { ConceptualEdge, ConceptualNode } from '@/interfaces/conceptual-map.ts';
+import type { ManualResourceData } from '@/interfaces/exploration.ts';
 import type { ManagementType } from '@/interfaces/initiation.ts';
-import type { ConceptualNode, ConceptualEdge, ResourceItem, ManualResourceData } from '@/interfaces/exploration.ts';
+import type { ResourceItem } from '@/interfaces/knowledge.ts';
 
 // --- Initialization ---
 const workflowStore = useWorkflowStore();

--- a/src/interfaces/exploration.ts
+++ b/src/interfaces/exploration.ts
@@ -1,4 +1,4 @@
-import { ID, DateTimeString, BaseChatMessage } from './core';
+import { ID, DateTimeString, ChatMessage } from './core';
 import { ConceptualNode, ConceptualEdge } from './conceptual-map';
 import { ResourceItem, ResearchFocus } from './knowledge';
 import { ReflectionLogEntry } from './workflow';
@@ -28,7 +28,7 @@ export interface ExplorationData {
  * Extends the base message to include research-specific UI elements
  * like suggested resources or structural changes (U.S. 11).
  */
-export interface AIChatMessage extends BaseChatMessage {
+export interface AIChatMessage extends ChatMessage {
   /** True if the message was sent by the user, false if from the AI. */
   isUser: boolean;
 


### PR DESCRIPTION
- Corrected the scope update API call to use apiService.knowledge instead of apiService.workflows to align with the backend structure.
- Refactored interface imports in ExplorationPage.vue and exploration.ts for better modularity.
- Updated AIChatMessage to extend ChatMessage instead of the deprecated BaseChatMessage.
- Cleaned up redundant and incorrectly ordered import statements.