### PR TITLE
feat(component): implement static graph infrastructure and VStaticGraph molecule

### DIFF
--- a/src/components/atoms/canvases/README.md
+++ b/src/components/atoms/canvases/README.md
@@ -25,7 +25,7 @@ The **Standardized Connection Port**. It wraps the Vue Flow `<Handle />` to prov
 * `position`: `Position.Top` | `Position.Bottom` | `Position.Left` | `Position.Right`.
 * `colorClass`: Tailwind background class (e.g., `bg-blue-500`) to match the node's theme.
 
-### 2. VNodeShape (New)
+### 2. VNodeShape
 
 The **Zoom-Resilient Vector Border**. Encapsulates SVG logic to maintain visual clarity across the coordinate system.
 
@@ -35,7 +35,7 @@ The **Zoom-Resilient Vector Border**. Encapsulates SVG logic to maintain visual 
 * `status`: `AI_EXTRACTED` (Dashed) | `LOCKED` (Solid).
 * `borderRadius`: (Number) Standardized at `12` for `rounded-xl` alignment.
 
-### 3. VNodeShield (New)
+### 3. VNodeShield
 
 The **Physical Background Surface**. Manages the base layer and elevation of the research entity.
 
@@ -45,6 +45,27 @@ The **Physical Background Surface**. Manages the base layer and elevation of the
 * `themeClass`: Tailwind utility for semantic coloring (e.g., `bg-emerald-50`).
 * `selected`: (Boolean) Triggers `ring` and `scale` transforms.
 * `padding`: `none` | `xs` | `sm` | `md`.
+
+### 4. VGraphEdge
+
+The **Visual Connectivity Vector**. A lightweight primitive for rendering relationships, optimized for non-interactive backgrounds and static molecules.
+
+* **Role**: **"Relationship" provider**. It bridges two spatial coordinates without the overhead of the Vue Flow edge lifecycle.
+* **Design Intent**: Uses the same dash-tokens as `VNodeShape` to ensure visual brand consistency across the landing page and the app.
+* **Key Props**:
+    * `x1, y1, x2, y2`: (Number/String) Start and end coordinates.
+    * `status`: `AI_EXTRACTED` (Dashed) | `LOCKED` (Solid).
+* **Differences from VNodeShape**: Unlike `VNodeShape`, which is a bounding box (`rect`), `VGraphEdge` is a directional vector (`line`).
+
+### 5. VGraphPoint
+
+The **Low-Fidelity Anchor**. A simplified, vector-based representation of a node used for visual "texture" on the landing page.
+
+* **Role**: **"Spatial Reference" provider**.
+* **Design Intent**: Strips away the complex layering of `VNodeShield` (no shadows, no handles) to maximize rendering speed in high-density static graphs.
+* **Key Props**:
+    * `x, y`: (Number/String) Center coordinate.
+    * `radius`: (Number) Standardized at `4` for a clean, professional look.
 
 ---
 
@@ -57,6 +78,9 @@ The **Physical Background Surface**. Manages the base layer and elevation of the
 > **Rule 4: Stroke Scaling.** Always use `VNodeShape` for borders instead of CSS `border` properties. This ensures the dash-gap ratio remains constant at low zoom levels.
 > **Rule 5: Surface Elevation.** `VNodeShield` must include `will-change: transform` to optimize GPU rendering during rapid canvas panning.
 > **Rule 6: Content Layering.** In a `VNodeContainer` (Molecule), the `VNodeShape` must be placed **after** the content to ensure the vector border remains the top-most visual layer.
+> **Rule 7: Static vs. Dynamic Separation.** Use `VGraphEdge/Point` for background visualizations and landing page molecules (`VStaticGraph`). Use `VNode*` atoms exclusively for the interactive `Auraflux-Beacon` workspace.
+> **Rule 8: Internal Consistency.** The `stroke-dasharray` of `VGraphEdge` must always match `VNodeShape` (8, 5) to maintain the semantic link between suggested data across the entire ecosystem.
+> **Rule 9: Namespace Purity.** Do not use `xmlns` links or external URIs within these atoms. They are designed to be rendered within a `VGraphCanvas` (Layout Atom) which manages the SVG environment.
 
 ### Correct Implementation Pattern
 
@@ -80,6 +104,7 @@ The **Physical Background Surface**. Manages the base layer and elevation of the
 | **Shield Active** | Transform | `scale-[1.02]` | Selection prominence |
 | **Shape Dash** | Pattern | `8, 5` (SVG Array) | AI Extraction signal |
 | **Shape Weight** | Stroke | `2.5px` | Zoom visibility |
+| **Graph Point** | Fill | `fill-current` | Color inheritance |
 
 ---
 
@@ -89,7 +114,9 @@ The **Physical Background Surface**. Manages the base layer and elevation of the
 src/components/atoms/canvases/
 ├── VNodeHandle.vue        # Standardized port component
 ├── VNodeShape.vue         # Zoom-resilient vector border
-└── VNodeShield.vue        # Background and elevation surface
+├── VNodeShield.vue        # Background and elevation surface
+├── VGraphEdge.vue         # Static connectivity vector
+├── VGraphPoint.vue        # Low-fidelity anchor point
 └── README.md              # You are here
 
 ```

--- a/src/components/atoms/canvases/VGraphEdge.vue
+++ b/src/components/atoms/canvases/VGraphEdge.vue
@@ -1,0 +1,34 @@
+<template>
+  <line
+    :x1="x1" :y1="y1" :x2="x2" :y2="y2"
+    class="v-graph-edge transition-all duration-700 stroke-current"
+    :class="status === 'AI_EXTRACTED' ? 'stroke-dash' : 'stroke-solid'"
+    vector-effect="non-scaling-stroke"
+  />
+</template>
+
+<script setup lang="ts">
+/**
+ * VGraphEdge Atom
+ * Responsibility: Renders connectivity with Auraflux-standard dash patterns.
+ */
+withDefaults(defineProps<{
+  x1: number | string;
+  y1: number | string;
+  x2: number | string;
+  y2: number | string;
+  status?: 'LOCKED' | 'AI_EXTRACTED';
+}>(), {
+  status: 'LOCKED'
+});
+</script>
+
+<style scoped>
+.stroke-dash {
+  stroke-dasharray: 8 5;
+  stroke-width: 1.5px;
+}
+.stroke-solid {
+  stroke-width: 2px;
+}
+</style>

--- a/src/components/atoms/canvases/VGraphPoint.vue
+++ b/src/components/atoms/canvases/VGraphPoint.vue
@@ -1,0 +1,17 @@
+<template>
+  <circle
+    :cx="x" :cy="y"
+    :r="radius"
+    class="v-graph-point fill-current transition-transform duration-300"
+  />
+</template>
+
+<script setup lang="ts">
+withDefaults(defineProps<{
+  x: number | string;
+  y: number | string;
+  radius?: number;
+}>(), {
+  radius: 4
+});
+</script>

--- a/src/components/atoms/layout/README.md
+++ b/src/components/atoms/layout/README.md
@@ -7,10 +7,9 @@ Layout atoms are the **architectural primitives** of the application. They enfor
 * **Separation of Concerns (Skin vs. Bones)**:
 * **Skin (`VBox`)**: Manages visual surface—Padding, Border, Background, and Rounding.
 * **Bones (`VStack`, `VCluster`)**: Manages spatial distribution—Gaps and alignment.
-
-
 * **Parent-Driven Spacing**: Individual atoms (like Buttons or Icons) **must never** have external margins. All spacing is managed by the parent Layout atom via the `gap` prop.
 * **Semantic Rendering**: Use the `tag` prop to ensure accessibility (e.g., `<VBox tag="section">`) without cluttering the DOM.
+* **Infrastructure (`VGraphCanvas`, `VGraphGroup`)**: Manages SVG spatial environments and semantic grouping.
 
 ---
 
@@ -40,6 +39,23 @@ The horizontal alignment engine. Replaces `.flex-row` patterns.
 ### 4. VSpacer
 
 A utility to create dynamic "pushes" using `flex-grow`.
+
+### 5. VGraphCanvas (The Viewport)
+
+The **Spatial Anchor**. Provides a standardized, non-interactive SVG viewport for static graphs and background textures.
+
+* **Role**: **"Coordinate System" provider**.
+* **Design Intent**: Replaces raw `<svg>` tags. It encapsulates the `viewBox` and `preserveAspectRatio` logic, ensuring the graph scales gracefully without layout shifts.
+* **Key Props**: `viewBox`, `aspectRatio`.
+* **Constraint**: Stripped of `xmlns` to prevent external URI references in the component layer.
+
+### 6. VGraphGroup (The Semantic Layer)
+
+The **SVG Logical Container**. Acts as a structural "wrapper" for related graph primitives.
+
+* **Role**: **"Context" provider**.
+* **Design Intent**: Replaces raw `<g>` tags. It allows the **Molecule** to apply thematic colors or opacities to a cluster of edges or points without repeating classes on every child.
+* **Key Props**: `colorClass` (Tailwind text-color or opacity utilities).
 
 ---
 
@@ -81,6 +97,9 @@ To maintain semantic integrity, only the following tokens are permitted:
 > **Rule 2: Token Discipline.** Strictly use `GapSize` and `BackgroundToken`. Custom hex codes or arbitrary Tailwind `bg-*` classes are prohibited.
 > **Rule 3: Geometric Consistency.** For Material-style cards, use `rounded="lg"` or `xl`. Layouts should always be responsive (e.g., `w-full h-full`).
 > **Rule 4: Zero Margin Bleed.** Ensure all spacing is handled via the `gap` prop of the parent.
+> **Rule 5: SVG Namespace Purity.** Never include `xmlns="http://www.w3.org/2000/svg"` in `VGraphCanvas`. Browser inference is preferred for component-level rendering.
+> **Rule 6: Structural Grouping.** Use `VGraphGroup` whenever two or more `VGraphEdge` or `VGraphPoint` atoms share the same reliability status (e.g., all Suggested edges).
+> **Rule 7: Background Recess.** Background graphs should always use `VGraphCanvas` with `pointer-events-none` to ensure they do not intercept clicks meant for the Hero section or Login buttons.
 
 ### Correct Implementation Pattern
 
@@ -101,6 +120,18 @@ To maintain semantic integrity, only the following tokens are permitted:
 
 ```
 
+```vue
+<VGraphCanvas viewBox="0 0 1440 800">
+  <VGraphGroup colorClass="text-slate-700/40">
+    <VGraphEdge x1="100" y1="100" x2="300" y2="200" />
+  </VGraphGroup>
+
+  <VGraphGroup colorClass="text-slate-600/20">
+    <VGraphEdge x1="300" y1="200" x2="500" y2="400" status="AI_EXTRACTED" />
+  </VGraphGroup>
+</VGraphCanvas>
+```
+
 ---
 
 ## 📂 Directory Structure
@@ -109,6 +140,8 @@ To maintain semantic integrity, only the following tokens are permitted:
 src/components/atoms/layout/
 ├── VBox.vue             # The Physical Shell (Skin)
 ├── VCluster.vue         # Horizontal Flex (Bones)
+├── VGraphCanvas.vue     # SVG Viewport Anchor
+├── VGraphGroup.vue      # SVG Semantic Group
 ├── VSpacer.vue          # Flex Push (Utility)
 ├── VStack.vue           # Vertical Rhythm (Bones)
 └── README.md            # You are here

--- a/src/components/atoms/layout/VGraphCanvas.vue
+++ b/src/components/atoms/layout/VGraphCanvas.vue
@@ -1,0 +1,24 @@
+<template>
+  <svg
+    :viewBox="viewBox"
+    :preserveAspectRatio="aspectRatio"
+    class="v-graph-canvas absolute inset-0 w-full h-full pointer-events-none select-none"
+    aria-hidden="true"
+  >
+    <slot />
+  </svg>
+</template>
+
+<script setup lang="ts">
+/**
+ * VGraphCanvas Atom
+ * Responsibility: Provides a standardized SVG viewport for static graphs.
+ */
+withDefaults(defineProps<{
+  viewBox?: string;
+  aspectRatio?: string;
+}>(), {
+  viewBox: '0 0 1440 800',
+  aspectRatio: 'xMidYMid slice'
+});
+</script>

--- a/src/components/atoms/layout/VGraphGroup.vue
+++ b/src/components/atoms/layout/VGraphGroup.vue
@@ -1,0 +1,16 @@
+<template>
+  <g :class="['v-graph-group', colorClass]">
+    <slot />
+  </g>
+</template>
+
+<script setup lang="ts">
+/**
+ * VGraphGroup Atom
+ * Responsibility: Semantic grouping of graph elements.
+ * Prevents "leaky" styling in the molecule.
+ */
+defineProps<{
+  colorClass?: string;
+}>();
+</script>

--- a/src/components/molecules/layout/README.md
+++ b/src/components/molecules/layout/README.md
@@ -21,11 +21,14 @@ A specialized floating trigger used to toggle the visibility or state of adjacen
 * **Logic**: Anchors to the edge of a parent container and moves in sync with panel transitions.
 * **Physics**: Uses `shadow-md` to signify elevation above the workspace surface.
 
-### 2. VResizableSplitter (Planned)
+### 2. VStaticGraph (New)
 
-A divider that allows users to manually adjust the width/height ratio between two layout regions.
+The **Foundational Visual Anchor**. Orchestrates static graph primitives to evoke "structural logic" on landing pages or entry gateways.
 
-* **Composition**: `VBox` (Visual line) > `HTML Drag Events`.
+* **Composition**: `VGraphCanvas` > `VGraphGroup` > `VGraphEdge` & `VGraphPoint`.
+* **Role**: **"Spatial Identity" provider**.
+* **Logic**: Strictly non-interactive. It uses fixed SVG coordinates to provide a consistent professional atmosphere.
+* **Semantics**: Uses the shared `8, 5` dash token via `VGraphEdge` to maintain visual lineage with the interactive workspace.
 
 ---
 
@@ -35,6 +38,9 @@ A divider that allows users to manually adjust the width/height ratio between tw
 > **Rule 1: Coordinate Synchronization.** When a layout molecule controls a panel, both components must share the same CSS transition curve (`ease-in-out`) and duration (`300ms`) to prevent visual lagging.
 > **Rule 2: Z-Index Discipline.** Layout molecules must use semantic z-index ranges. For example, `z-40` for floating controls ensures they sit above sidebars (`z-20`) but below modals (`z-50`).
 > **Rule 3: Prop-Based Offsets.** Avoid hardcoding pixel values like `right: 384px`. Use props like `offset` so the layout can adapt to different sidebar widths.
+> **Rule 4: Background Recess.** `VStaticGraph` must always be wrapped in a container with `overflow-hidden` and positioned at the lowest possible z-index (`z-0` or `z-[-1]`).
+> **Rule 5: Pointer Neutrality.** Ensure `VStaticGraph` utilizes the `pointer-events-none` attribute from its underlying `VGraphCanvas` atom to prevent it from intercepting clicks on foreground CTA buttons.
+> **Rule 6: Atomic Orchestration.** Never use raw `<line>` or `<circle>` tags inside `VStaticGraph`. Use the corresponding `VGraphEdge` and `VGraphPoint` atoms to ensure design token synchronization.
 
 ### Standard Implementation Pattern
 
@@ -50,6 +56,20 @@ A divider that allows users to manually adjust the width/height ratio between tw
 
 ```
 
+```vue
+<template>
+  <VStaticGraph>
+    <VGraphGroup colorClass="text-slate-700/40">
+      <VGraphEdge x1="100" y1="200" x2="400" y2="300" />
+    </VGraphGroup>
+
+    <VGraphGroup colorClass="text-slate-600/20">
+      <VGraphEdge x1="400" y1="300" x2="700" y2="450" status="AI_EXTRACTED" />
+    </VGraphGroup>
+  </VStaticGraph>
+</template>
+```
+
 ---
 
 ## 🎨 Layout & Elevation Tokens
@@ -60,6 +80,8 @@ A divider that allows users to manually adjust the width/height ratio between tw
 | **Floating Depth** | Elevation | `shadow-md` |
 | **Z-Index: Controls** | Floating triggers | `z-40` |
 | **Z-Index: Panels** | Navigation units | `z-20` |
+| **Edge Semantics** | Reliability | Solid (Verified) / Dashed (AI) |
+| **Point Radius** | Anchor Size | `4px` (Standard) |
 
 ---
 
@@ -68,7 +90,7 @@ A divider that allows users to manually adjust the width/height ratio between tw
 ```text
 src/components/molecules/layout/
 ├── VFloatControl.vue      # Floating panel triggers
-├── VResizableSplitter.vue  # Interactive region dividers (Draft)
+├── VStaticGraph.vue       # [NEW] Foundational visual anchor
 └── README.md              # You are here
 
 ```

--- a/src/components/molecules/layout/VStaticGraph.vue
+++ b/src/components/molecules/layout/VStaticGraph.vue
@@ -1,0 +1,28 @@
+<template>
+  <VGraphCanvas viewBox="0 0 1440 900">
+
+    <VGraphGroup colorClass="text-slate-700/40">
+      <VGraphEdge :x1="150" :y1="200" :x2="400" :y2="350" />
+      <VGraphEdge :x1="400" :y1="350" :x2="650" :y2="250" />
+    </VGraphGroup>
+
+    <VGraphGroup colorClass="text-slate-600/30">
+      <VGraphEdge :x1="400" :y1="350" :x2="380" :y2="600" :status="'AI_EXTRACTED'" />
+    </VGraphGroup>
+
+    <VGraphGroup colorClass="text-slate-500/60">
+      <VGraphPoint :x="150" :y="200" />
+      <VGraphPoint :x="400" :y="350" :radius="5" />
+      <VGraphPoint :x="650" :y="250" />
+      <VGraphPoint :x="380" :y="600" />
+    </VGraphGroup>
+
+  </VGraphCanvas>
+</template>
+
+<script setup lang="ts">
+import VGraphCanvas from '@/components/atoms/layout/VGraphCanvas.vue';
+import VGraphGroup from '@/components/atoms/layout/VGraphGroup.vue';
+import VGraphEdge from '@/components/atoms/canvases/VGraphEdge.vue';
+import VGraphPoint from '@/components/atoms/canvases/VGraphPoint.vue';
+</script>


### PR DESCRIPTION
Add a suite of atomic and molecular components to support non-interactive SVG background visualizations. This implementation follows Atomic Design principles by separating SVG infrastructure from visual primitives.

- Create `VGraphCanvas` and `VGraphGroup` layout atoms to manage SVG viewports and semantic grouping.
- Create `VGraphEdge` and `VGraphPoint` canvas atoms for lightweight, non-interactive connectivity rendering.
- Implement `VStaticGraph` molecule to orchestrate the foundational visual anchor for landing pages.
- Update architectural documentation with new implementation rules for spatial consistency and SVG namespace purity.