### PR TITLE
feat(router): implement nested layouts and standalone LandingPage

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,18 +1,3 @@
 <template>
-  <AppTemplate>
-    <RouterView />
-  </AppTemplate>
+  <RouterView />
 </template>
-
-<script setup lang="ts">
-import AppTemplate from '@/components/templates/AppTemplate.vue';
-import { useAuthStore } from '@/stores/auth';
-import { onMounted } from 'vue';
-
-const authStore = useAuthStore();
-
-onMounted(() => {
-  // 1. Check for valid JWT cookie on initial load
-  authStore.checkAuthStatus();
-});
-</script>

--- a/src/components/molecules/indicators/VISPStepCard.vue
+++ b/src/components/molecules/indicators/VISPStepCard.vue
@@ -1,60 +1,66 @@
 <template>
   <VBox
-    :background="isActive ? 'white' : 'transparent'"
-    :border="isActive ? 'all' : 'none'"
-    padding="md"
+    :background="'white'"
+    :border="'none'"
+    :padding="size === 'lg' ? 'lg' : 'md'"
     rounded="xl"
-    class="transition-all duration-300 group"
-    :class="!isActive && !isCompleted ? 'opacity-50' : 'opacity-100'"
+    :class="[
+      'transition-all duration-300 group w-full',
+      'shadow-lg border-indigo-200 translate-x-2',
+    ]"
   >
-    <VStack gap="sm" align="center">
+    <VCluster gap="md" align="center">
       <VBox
-        :background="isActive ? 'indigo-50' : 'slate-50'"
-        padding="sm"
-        rounded="full"
+        :background="'white'"
+        :padding="size === 'lg' ? 'md' : 'sm'"
+        rounded="lg"
+        class="shadow-sm transition-colors duration-300"
       >
         <VIcon
           :name="icon"
-          :type="isActive ? 'solid' : 'outline'"
-          :color="isActive ? 'indigo-600' : 'slate-400'"
-          size="lg"
+          :type="'solid'"
+          :size="size === 'lg' ? 'xl' : 'lg'"
         />
       </VBox>
 
-      <VStack gap="none" align="center" class="text-center">
+      <VStack gap="none" align="start">
         <VTypography
           tag="strong"
-          size="base"
-          :weight="isActive ? 'bold' : 'medium'"
-          :color="isActive ? 'slate-900' : 'slate-500'"
+          :size="size === 'lg' ? 'lg' : 'md'"
+          :weight="'bold'"
+          :color="'slate-900'"
+          class="tracking-tight uppercase"
         >
           {{ label }}
         </VTypography>
 
         <VTypography
-          tag="span"
-          size="xs"
+          tag="p"
+          :size="'sm'"
+          :weight="'normal'"
           color="slate-400"
-          class="italic"
+          class="leading-relaxed max-w-prose"
         >
-          {{ subLabel }}
+          {{ description }}
         </VTypography>
       </VStack>
-    </VStack>
+    </VCluster>
   </VBox>
 </template>
 
 <script setup lang="ts">
+import VIcon from '@/components/atoms/indicators/VIcon.vue';
+import VTypography from '@/components/atoms/indicators/VTypography.vue';
 import VBox from '@/components/atoms/layout/VBox.vue';
+import VCluster from '@/components/atoms/layout/VCluster.vue';
 import VStack from '@/components/atoms/layout/VStack.vue';
-import VTypography from '@/components/atoms/VTypography.vue';
-import VIcon from '@/components/atoms/VIcon.vue';
 
-defineProps<{
-  label: string;       // e.g., "Define"
-  subLabel: string;    // e.g., "Clarify Anxiety"
-  icon: string;        // e.g., "magnifying-glass"
-  isActive?: boolean;
-  isCompleted?: boolean;
-}>();
+withDefaults(defineProps<{
+  label: string;
+  description: string;
+  icon: string;
+  size?: 'md' | 'lg'; // Added for Landing Page scaling
+}>(), {
+  size: 'md'
+});
 </script>

--- a/src/components/molecules/navs/VWelcomeGateway.vue
+++ b/src/components/molecules/navs/VWelcomeGateway.vue
@@ -1,52 +1,51 @@
 <template>
-  <VBox padding="xl" class="max-w-3xl mx-auto text-center">
+  <VBox padding="xl" class="max-w-3xl mx-auto text-center" :background="'white'">
     <VStack gap="xl" align="center">
       <VStack gap="xs">
         <VTypography variant="display" tag="h1" color="slate-900">
           {{ greeting }}
         </VTypography>
         <VTypography variant="base" color="slate-500">
-          Set your intent to prime the co-thinking session.
+          Declare your mindset to prime your mission control.
         </VTypography>
       </VStack>
 
-      <VCluster gap="sm" justify="center">
+      <VStack gap="sm">
         <VButton
           v-for="intent in intents"
           :key="intent.id"
           :variant="selectedIntent === intent.id ? 'primary' : 'outline'"
           rounded="full"
-          @click="selectedIntent = intent.id"
+          @click="handleIntentSelection(intent)"
         >
           <VCluster gap="xs">
             <VIcon :name="intent.icon" size="sm" />
-            <VTypography variant="sm" tag="span">
+            <VTypography variant="sm" tag="span" :color="selectedIntent === intent.id ? 'white' : 'slate-900'">
               {{ intent.label }}
             </VTypography>
           </VCluster>
         </VButton>
-      </VCluster>
+      </VStack>
 
       <VButton
         size="lg"
         color="indigo-600"
-        :disabled="!selectedIntent"
         class="w-full md:w-auto px-12"
         @click="$emit('launch', selectedIntent)"
       >
-        Start Session
+        LAUNCH MISSION CONTROL
       </VButton>
     </VStack>
   </VBox>
 </template>
 
 <script setup lang="ts">
+import VButton from '@/components/atoms/buttons/VButton.vue';
+import VIcon from '@/components/atoms/indicators/VIcon.vue';
+import VTypography from '@/components/atoms/indicators/VTypography.vue';
 import VBox from '@/components/atoms/layout/VBox.vue';
 import VCluster from '@/components/atoms/layout/VCluster.vue';
 import VStack from '@/components/atoms/layout/VStack.vue';
-import VButton from '@/components/atoms/VButton.vue';
-import VIcon from '@/components/atoms/VIcon.vue';
-import VTypography from '@/components/atoms/VTypography.vue';
 import type { IntentOption } from '@/interfaces/user';
 import { ref } from 'vue';
 
@@ -60,4 +59,9 @@ const selectedIntent = ref<string | null>(null);
 defineEmits<{
   (e: 'launch', intentId: string | null): void;
 }>();
+
+const handleIntentSelection = (intent: IntentOption) => {
+  selectedIntent.value = selectedIntent.value === intent.id ? null : intent.id
+}
+
 </script>

--- a/src/components/pages/ISearchPage.vue
+++ b/src/components/pages/ISearchPage.vue
@@ -1,0 +1,18 @@
+<template>
+  <AppTemplate>
+    <RouterView />
+  </AppTemplate>
+</template>
+
+<script setup lang="ts">
+import AppTemplate from '@/components/templates/AppTemplate.vue';
+import { useAuthStore } from '@/stores/auth';
+import { onMounted } from 'vue';
+
+const authStore = useAuthStore();
+
+onMounted(() => {
+  // Check for valid JWT cookie on initial load
+  authStore.checkAuthStatus();
+});
+</script>

--- a/src/components/pages/LandingPage.vue
+++ b/src/components/pages/LandingPage.vue
@@ -1,0 +1,97 @@
+<template>
+  <VBox
+    tag="main"
+    class="relative min-h-screen flex items-center justify-center overflow-hidden"
+    background="slate-50"
+  >
+    <VBox position="absolute" inset="0" z-index="0" class="opacity-20 pointer-events-none">
+      <VStaticGraph v-if="isGraphLoaded" />
+    </VBox>
+
+    <VBox position="relative" z-index="10" class="w-full max-w-7xl px-16">
+
+      <VStack gap="md" class="pt-6 mb-6">
+        <VTypography tag="h1" size="4xl" weight="bold" color="slate-900">FROM CONFUSION TO ACTION.</VTypography>
+        <VTypography tag="p" size="lg" weight="normal" color="slate-600">
+          Navigate your knowledge flow: from defining ambiguity to structured decision-making.
+        </VTypography>
+      </VStack>
+
+      <VCluster gap="xl" align="start" justify="between" class="w-full">
+
+        <VStack gap="md" class="flex-[1.6] min-w-[500px]">
+          <VISPStepCard
+            label="DEFINE: CLARIFY ANXIETY"
+            description="Acknowledge the initial ambiguity of a new challenge. Use this phase to identify known unknowns and set cognitive boundaries, transforming vague uncertainty into a structured problem space for exploration."
+            icon="MagnifyingGlass"
+          />
+          <VISPStepCard
+            label="CONNECT: MAP HIDDEN RELATIONS"
+            description="Surface the underlying architecture of your information. By visualizing nodes and their dependencies, you can uncover non-obvious correlations and structural patterns that traditional linear searching often misses."
+            icon="Share"
+          />
+          <VISPStepCard
+            label="ACT: TRIGGER DECISION"
+            description="Synthesize mapped insights into a logical trajectory. This final stage focuses on reducing cognitive load to trigger a confident, evidence-based decision, moving from raw data to purposeful execution."
+            icon="Bolt"
+          />
+        </VStack>
+
+        <VWelcomeGateway
+          :greeting="greeting"
+          :intents="intents"
+          @launch="handleLaunch"
+        />
+
+      </VCluster>
+    </VBox>
+  </VBox>
+</template>
+
+<script setup lang="ts">
+import VTypography from '@/components/atoms/indicators/VTypography.vue';
+import VBox from '@/components/atoms/layout/VBox.vue';
+import VCluster from '@/components/atoms/layout/VCluster.vue';
+import VStack from '@/components/atoms/layout/VStack.vue';
+import VISPStepCard from '@/components/molecules/indicators/VISPStepCard.vue';
+import VStaticGraph from '@/components/molecules/layout/VStaticGraph.vue';
+import VWelcomeGateway from '@/components/molecules/navs/VWelcomeGateway.vue';
+import type { IntentOption } from '@/interfaces/user';
+import { onMounted, ref } from 'vue';
+
+const greeting = ref<string>("Ready to map hidden relations?");
+const intents = ref<IntentOption[]>([
+  {
+    id: 'exploratory',
+    label: 'Exploratory',
+    icon: 'MagnifyingGlass', // Focus: Clarifying the unknown
+  },
+  {
+    id: 'structural',
+    label: 'Structural',
+    icon: 'RectangleGroup', // Focus: Organizing existing nodes
+  },
+  {
+    id: 'decision',
+    label: 'Decision-focused',
+    icon: 'Bolt', // Focus: Triggering an actionable output
+  },
+  {
+    id: 'evaluative',
+    label: 'Critical Review',
+    icon: 'ShieldCheck', // Focus: Red-teaming or validating logic
+  }
+]);
+
+const isGraphLoaded = ref(false);
+
+onMounted(() => {
+  // Delay ensures the Functional Molecules are interactive first
+  setTimeout(() => { isGraphLoaded.value = true; }, 400);
+});
+
+const handleLaunch = (intentId: string | null) => {
+  if (!intentId) return;
+  console.log(`Transitioning to workspace with intent: ${intentId}`);
+};
+</script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,19 +1,33 @@
 import InitiationPage from '@/components/pages/InitiationPage.vue';
+import LandingPage from '@/components/pages/LandingPage.vue';
 import ExplorationPage from '@/components/pages/ExplorationPage.vue';
+import ISearchPage from '@/components/pages/ISearchPage.vue';
 import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router';
 
 
 export const routes: Array<RouteRecordRaw> = [
   {
     path: '/',
-    name: 'InitiationPage',
-    component: InitiationPage
+    name: 'LandingPage',
+    component: LandingPage
   },
   {
-    path: '/exploration',
-    name: 'ExplorationPage',
-    component: ExplorationPage
-  },
+    path: '/isearch',
+    name: 'ISearchPage',
+    component: ISearchPage,
+    children: [
+      {
+        path: 'initiation',
+        name: 'InitiationPage',
+        component: InitiationPage
+      },
+      {
+        path: 'exploration',
+        name: 'ExplorationPage',
+        component: ExplorationPage
+      },
+    ]
+  }
 ]
 
 const router = createRouter({

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -2,10 +2,12 @@ import type { User } from '@/interfaces/user';
 import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
 import { apiService } from '@/api/apiService';
+import { useRouter } from 'vue-router';
 
 export const useAuthStore = defineStore('auth', () => {
   // --- State ---
 
+  const router = useRouter();
   // Use 'ref' to create reactive state properties
   const user = ref<User | null>(null);
   const loading = ref(false); // Tracks if the initial auth check is running
@@ -36,10 +38,12 @@ export const useAuthStore = defineStore('auth', () => {
       } else {
         // 401 Unauthorized or other error means the user is not logged in or the token expired
         user.value = null;
+        router.push('/');
       }
     } catch (error) {
       console.error('Error during initial authentication check:', error);
       user.value = null;
+      router.push('/');
     } finally {
       loading.value = false;
     }


### PR DESCRIPTION
Refactor the application architecture to support a standalone LandingPage and a nested layout for internal search routes.

- Move global AppTemplate and auth check from App.vue to ISearchPage.
- Define ISearchPage as a layout wrapper for nested internal routes.
- Add LandingPage with the high-impact "Flight Deck" ISP methodology map.
- Refactor VISPStepCard to support multi-line descriptions and responsive scaling.
- Update VWelcomeGateway with a vertical intent selection flow and white background.
- Update auth store to redirect users to LandingPage on unauthorized/expired sessions.
- Clean up App.vue to serve as a pure entry point.