### PR TITLE
Refactor(canvas): Resolve Architectural Self-Injection Restrictions and Isolate Interaction States to Scoped Sandbox

### DIFF
--- a/src/components/molecules/canvases/VEdgeFloatingEditor.vue
+++ b/src/components/molecules/canvases/VEdgeFloatingEditor.vue
@@ -1,7 +1,7 @@
 <template>
   <EdgeLabelRenderer>
     <VBox
-      v-if="isInterceptionActive"
+      v-if="context.isInterceptionActive.value"
       tag="div"
       background="white"
       padding="md"
@@ -10,8 +10,8 @@
       class="w-72 shadow-xl animate-in fade-in zoom-in duration-200 nodrag nopan"
       :style="{
         position: 'absolute',
-        left: `${interceptorPosition.x}px`,
-        top: `${interceptorPosition.y}px`,
+        left: `${context.interceptorPosition.x}px`,
+        top: `${context.interceptorPosition.y}px`,
         transform: 'translate(-50%, -50%)',
         pointerEvents: 'all',
         zIndex: 1000,
@@ -35,7 +35,7 @@
 
         <VFormField id="edge-type" label="Relationship Type">
           <VSelect
-            v-model="localType"
+            v-model="context.localEdgeData.value.type"
             size="sm"
           >
             <option
@@ -50,7 +50,7 @@
 
         <VFormField id="edge-label" label="Logical Label (Optional)">
           <VInput
-            v-model="localLabel"
+            v-model="context.localEdgeData.value.label"
             placeholder="e.g., influences, triggers..."
             size="sm"
           />
@@ -58,7 +58,7 @@
 
         <VFormField id="edge-evidence" label="Evidence / Rationale">
           <VTextarea
-            v-model="localEvidence"
+            v-model="context.localEdgeData.value.evidence"
             placeholder="Cite evidence or reasoning..."
             :rows="2"
             size="sm"
@@ -68,7 +68,7 @@
         <VCluster justify="end" gap="sm" class="pt-2">
 
           <VButton
-            v-if="interceptorAction === 'update'"
+            v-if="context.interceptorAction.value === 'update'"
             variant="danger"
             size="sm"
             @click="handleDelete"
@@ -81,7 +81,7 @@
           </VButton>
  -->
           <VButton variant="primary" size="sm" @click="confirmRelation">
-            {{ interceptorAction == 'create' ? 'Create' : 'Update' }} Link
+            {{ context.interceptorAction.value == 'create' ? 'Create' : 'Update' }} Link
           </VButton>
 
 
@@ -92,9 +92,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { inject } from 'vue';
 import { EdgeLabelRenderer } from '@vue-flow/core';
 import { useEdgeInterceptor } from '@/composables/useEdgeInterceptor';
+import { ConceptualMapContextKey } from '@/constants/injection-keys';
 
 // Atoms & Molecules (Assuming standard naming from your stack)
 import VBox from '@/components/atoms/layout/VBox.vue';
@@ -107,9 +108,13 @@ import VSelect from '@/components/atoms/forms/VSelect.vue';
 import VTextarea from '@/components/atoms/forms/VTextarea.vue';
 import VFormField from '@/components/molecules/forms/VFormField.vue';
 
-import { useCanvasStore } from '@/stores/canvas';
+const context = inject(ConceptualMapContextKey);
 
-const canvasStore = useCanvasStore();
+if (!context) {
+  throw new Error(
+    '[Architectural Violation] VEdgeFloatingEditor must be rendered within the tree of a <ConceptualMapCanvas>.'
+  );
+}
 
 /**
  * VEdgeFloatingEditor Molecule
@@ -132,30 +137,14 @@ const edgeTypeOptions = [
   { label: 'Structural Link', value: 'LINK' },
 ];
 
-const isInterceptionActive = computed(() => canvasStore.current?.isInterceptionActive);
-const interceptorAction = computed(() => canvasStore.current?.interceptorAction);
-const interceptorPosition = computed(() => canvasStore.current?.interceptorPosition!);
-const localType = computed({
-  get: () => canvasStore.current?.localEdgeData.type ?? 'REF',
-  set: (val) => canvasStore.updateLocalEdgeData({type: val})
-});
-const localLabel= computed({
-  get: () => canvasStore.current?.localEdgeData.label,
-  set: (val) => canvasStore.updateLocalEdgeData({label: val})
-});
-const localEvidence = computed({
-  get: () => canvasStore.current?.localEdgeData.evidence,
-  set: (val) => canvasStore.updateLocalEdgeData({evidence: val})
-});
-
 function close() {
-  canvasStore.setInterceptionActivity(false);
+  context!.closeInterceptor();
 };
 
 function handleDelete() {
   if (confirm('Delete this relationship?')) {
-    canvasStore.updateConceptualMapEdge(canvasStore.current?.localEdgeData!, 'delete');
-    canvasStore.closeInterceptor();
+    context!.updateConceptualMapEdge(context!.localEdgeData.value, 'delete');
+    context!.closeInterceptor();
   };
 };
 

--- a/src/components/molecules/canvases/VEdgeFloatingEditor.vue
+++ b/src/components/molecules/canvases/VEdgeFloatingEditor.vue
@@ -108,21 +108,16 @@ import VSelect from '@/components/atoms/forms/VSelect.vue';
 import VTextarea from '@/components/atoms/forms/VTextarea.vue';
 import VFormField from '@/components/molecules/forms/VFormField.vue';
 
-const context = inject(ConceptualMapContextKey);
-
-if (!context) {
-  throw new Error(
-    '[Architectural Violation] VEdgeFloatingEditor must be rendered within the tree of a <ConceptualMapCanvas>.'
-  );
-}
-
 /**
  * VEdgeFloatingEditor Molecule
  * Provides a UI overlay to define semantic metadata when a new connection is initiated.
  * Integrated with useEdgeInterceptor for state management.
  */
 const {
+  context,
+  cancelRelation,
   confirmRelation,
+  deleteRelation,
 } = useEdgeInterceptor();
 
 /**
@@ -138,13 +133,12 @@ const edgeTypeOptions = [
 ];
 
 function close() {
-  context!.closeInterceptor();
+  cancelRelation();
 };
 
 function handleDelete() {
   if (confirm('Delete this relationship?')) {
-    context!.updateConceptualMapEdge(context!.localEdgeData.value, 'delete');
-    context!.closeInterceptor();
+    deleteRelation();
   };
 };
 

--- a/src/components/molecules/navs/VTreeItem.vue
+++ b/src/components/molecules/navs/VTreeItem.vue
@@ -86,13 +86,10 @@ import VTypography from '@/components/atoms/indicators/VTypography.vue';
 import VBox from '@/components/atoms/layout/VBox.vue';
 import VCluster from '@/components/atoms/layout/VCluster.vue';
 import VStack from '@/components/atoms/layout/VStack.vue';
-import { useCanvasDrop } from '@/composables/useCanvasDrop';
 import type { ConceptualNode } from '@/interfaces/conceptual-map';
 import { computed } from 'vue';
 
 defineOptions({ inheritAttrs: false });
-
-const { onDragStart } = useCanvasDrop();
 
 const props = defineProps<{
   node: ConceptualNode;
@@ -152,7 +149,10 @@ const solidityStyles = computed(() => {
 });
 
 const handleDragStart = (event: DragEvent) => {
-  onDragStart(event, props.node);
+  if (event.dataTransfer) {
+    event.dataTransfer.setData('application/vueflow-node-id', props.node.id);
+    event.dataTransfer.effectAllowed = 'move';
+  }
 }
 </script>
 

--- a/src/components/molecules/navs/VTreeItem.vue
+++ b/src/components/molecules/navs/VTreeItem.vue
@@ -150,7 +150,7 @@ const solidityStyles = computed(() => {
 
 const handleDragStart = (event: DragEvent) => {
   if (event.dataTransfer) {
-    event.dataTransfer.setData('application/vueflow-node-id', props.node.id);
+    event.dataTransfer.setData('application/vueflow', JSON.stringify(props.node))
     event.dataTransfer.effectAllowed = 'move';
   }
 }

--- a/src/components/organisms/canvases/ConceptualMapCanvas.vue
+++ b/src/components/organisms/canvases/ConceptualMapCanvas.vue
@@ -62,10 +62,11 @@
 </template>
 
 <script setup lang="ts">
+import type { ID } from '@/interfaces/core';
 import { Background } from '@vue-flow/background';
 import { Controls } from '@vue-flow/controls';
-import { VueFlow, type Edge, type EdgeUpdateEvent, type NodeDragEvent, type EdgeMouseEvent } from '@vue-flow/core';
-import { computed, markRaw, ref } from 'vue';
+import { VueFlow, type EdgeMouseEvent, type NodeDragEvent } from '@vue-flow/core';
+import { computed, markRaw, provide, ref, watch } from 'vue';
 
 // Atoms & Molecules
 import VButton from '@/components/atoms/buttons/VButton.vue';
@@ -82,16 +83,42 @@ import VConceptualEdge from '@/components/organisms/canvases/VConceptualEdge.vue
 import VConceptualNode from '@/components/organisms/canvases/VConceptualNode.vue';
 
 import { useCanvasDrop } from '@/composables/useCanvasDrop';
+import { useConceptualMapContext } from '@/composables/useConceptualMapContext';
 import { useEdgeInterceptor } from '@/composables/useEdgeInterceptor';
+import { ConceptualMapContextKey } from '@/constants/injection-keys';
 import type { ConceptualEdge, ConceptualNode } from '@/interfaces/conceptual-map';
-import { useCanvasStore } from '@/stores/canvas';
 
 const props = defineProps<{
-  nodes: ConceptualNode[];
-  edges: ConceptualEdge[];
+  projectId: ID;
+  canvasId: ID;
+  registryCount: number;
 }>();
 
-const canvasStore = useCanvasStore();
+const isLoading = ref(false);
+
+const canvasContext = useConceptualMapContext(props.canvasId, {
+  getProjectId: () => props.projectId,
+  getRegistryCount: () => props.registryCount
+});
+provide(ConceptualMapContextKey, canvasContext);
+
+watch(
+  () => props.canvasId,
+  async (newId) => {
+    if (!newId) return;
+    try {
+      isLoading.value = true;
+      // Context encapsulates its own asynchronous fetching flow
+      await canvasContext.fetchGraphData();
+    } catch (error) {
+      console.error('[Canvas Initialize Error] Fetch failed:', error);
+    } finally {
+      isLoading.value = false;
+    }
+  },
+  { immediate: true }
+);
+
 const { onDragOver, onDrop, onDragLeave } = useCanvasDrop();
 const { startInterception } = useEdgeInterceptor();
 
@@ -117,7 +144,7 @@ const nodeTypes = {
   GROUP: markRaw(VConceptualNode),
 };
 
-const vueFlowNodes = computed(() => props.nodes.map(n => ({
+const vueFlowNodes = computed(() => Array.from(canvasContext.conceptualNodes.values()).map(n => ({
   id: n.id,
   position: { x: n.position?.x ?? 0, y: n.position?.y ?? 0 },
   data: { ...n },
@@ -125,7 +152,7 @@ const vueFlowNodes = computed(() => props.nodes.map(n => ({
   dragHandle: '.v-node-container',
 })));
 
-const vueFlowEdges = computed(() => props.edges.map(e => ({
+const vueFlowEdges = computed(() => canvasContext.conceptualEdges.value.map(e => ({
   id: e.id,
   source: e.source,
   sourceHandle: e.sourceHandle,
@@ -147,7 +174,7 @@ const localLabel = ref('');
 const localNotes = ref('');
 
 function handleConnect(connection: any) {
-  startInterception(connection, canvasStore.current?.conceptualNodes ?? new Map());
+  startInterception(connection, canvasContext.conceptualNodes);
 }
 
 function handleNodeDragStop({ node }: NodeDragEvent) {
@@ -155,7 +182,7 @@ function handleNodeDragStop({ node }: NodeDragEvent) {
     ...node.data,
     position: { x: node.position.x, y: node.position.y }
   };
-  canvasStore.updateConceptualMapNode(updatedNode, 'move');
+  canvasContext.updateConceptualMapNode(updatedNode, 'move');
 }
 
 function handleEdgeDoubleClick({ event, edge }: EdgeMouseEvent) {
@@ -167,10 +194,10 @@ function handleEdgeDoubleClick({ event, edge }: EdgeMouseEvent) {
     y: (edge.sourceY + edge.targetY) / 2,
   };
 
-  const rawEdgeData = props.edges.find((e) => e.id === edge.id);
+  const rawEdgeData = canvasContext.conceptualEdges.value.find((e: ConceptualEdge) => e.id === edge.id);
 
   if (rawEdgeData) {
-    canvasStore.openInterceptor(null, midpoint, rawEdgeData);
+    canvasContext.openInterceptor(null, midpoint, rawEdgeData);
   }
 }
 
@@ -179,7 +206,8 @@ function handleNodeDoubleClick(event: any) {
 }
 
 function startEdit(nodeId: string) {
-  const node = props.nodes.find(n => n.id === nodeId);
+  const node = canvasContext.conceptualNodes.get(nodeId);
+
   if (node) {
     editingNode.value = node;
     localLabel.value = node.label;
@@ -196,7 +224,7 @@ function saveEdit() {
       userNotes: localNotes.value
     };
 
-    canvasStore.updateConceptualMapNode(updatedNode, 'edit');
+    canvasContext.updateConceptualMapNode(updatedNode, 'edit');
     isEditModalOpen.value = false;
   }
 }

--- a/src/components/organisms/canvases/ConceptualMapCanvas.vue
+++ b/src/components/organisms/canvases/ConceptualMapCanvas.vue
@@ -96,7 +96,8 @@ const props = defineProps<{
 
 const isLoading = ref(false);
 
-const canvasContext = useConceptualMapContext(props.canvasId, {
+const canvasContext = useConceptualMapContext({
+  getCanvasId: () => props.canvasId,
   getProjectId: () => props.projectId,
   getRegistryCount: () => props.registryCount
 });
@@ -106,6 +107,7 @@ watch(
   () => props.canvasId,
   async (newId) => {
     if (!newId) return;
+
     try {
       isLoading.value = true;
       // Context encapsulates its own asynchronous fetching flow
@@ -119,8 +121,8 @@ watch(
   { immediate: true }
 );
 
-const { onDragOver, onDrop, onDragLeave } = useCanvasDrop();
-const { startInterception } = useEdgeInterceptor();
+const { onDragOver, onDrop, onDragLeave } = useCanvasDrop(canvasContext);
+const { startInterception } = useEdgeInterceptor(canvasContext);
 
 const edgeTypes = {
   REF: markRaw(VConceptualEdge),

--- a/src/components/organisms/canvases/VNodeContainer.vue
+++ b/src/components/organisms/canvases/VNodeContainer.vue
@@ -24,15 +24,20 @@
  * The physical shell for all canvas nodes.
  * Implements semantic border logic (Solid/Dashed) and hover/selection states.
  */
+import { inject } from 'vue';
 import VNodeShape from '@/components/atoms/canvases/VNodeShape.vue';
 import VNodeShield from '@/components/atoms/canvases/VNodeShield.vue';
 import VNodeActionGroup from '@/components/molecules/canvases/VNodeActionGroup.vue';
-import { useProjectExploration } from '@/composables/useProjectExploration';
-import { useCanvasStore } from '@/stores/canvas';
 import { computed } from 'vue';
+import { ConceptualMapContextKey } from '@/constants/injection-keys';
 
-const canvasStore = useCanvasStore();
-const { updateConeptualNode } = useProjectExploration();
+const context = inject(ConceptualMapContextKey);
+
+if (!context) {
+  throw new Error(
+    '[Architectural Violation] VNodeContainer must be rendered within the tree of a <ConceptualMapCanvas>.'
+  );
+}
 
 const props = withDefaults(defineProps<{
   id: string
@@ -51,25 +56,26 @@ const props = withDefaults(defineProps<{
   padding: 'md'
 })
 
-const nodeData = computed(() => canvasStore.current?.conceptualNodes.get(props.id));
+const nodeData = computed(() => context.conceptualNodes.get(props.id));
 
 /**
  * Technical Logic: Operation Handlers
  * These functions bubble events up to the Page/Canvas level where
  * the Exploration Store (exploration.ts) resides.
  */
-const handleAccept = () => {
+const handleAccept = async () => {
   let node = nodeData.value;
   if (node !== undefined) {
     node.status = 'LOCKED';
-    updateConeptualNode(node);
+    await context.updateConceptualMapNode(node, 'edit');
+    context.recommendConceptualNodes();
   }
 }
 
 const handleReject = () => {
   let node = nodeData.value;
   if (node !== undefined) {
-    canvasStore.updateConceptualMapNode(node, 'delete');
+    context.updateConceptualMapNode(node, 'delete');
   }
 }
 </script>

--- a/src/components/pages/ExplorationPage.vue
+++ b/src/components/pages/ExplorationPage.vue
@@ -12,10 +12,9 @@
         <main class="relative h-full w-full">
           <ConceptualMapCanvas
             ref="canvas"
-            :nodes="canvasStore.current ? Array.from(canvasStore.current.conceptualNodes.values()) : []"
-            :edges="canvasStore.current ? canvasStore.current.conceptualEdges: []"
-            :health-scores="explorationStore.stabilityScore"
-            :active-view-id="explorationStore.activeCanvasId"
+            :project-id="currentProjectId"
+            :canvas-id="explorationStore.activeCanvasId"
+            :registry-count="explorationStore.sidebarNodes.size"
           />
         </main>
       </template>
@@ -70,7 +69,6 @@
  */
 import { useProjectExploration } from '@/composables/useProjectExploration';
 import { useRegistry } from '@/composables/useRegistry';
-import { useCanvasStore } from '@/stores/canvas';
 import { useExplorationStore } from '@/stores/exploration';
 import { onMounted, ref } from 'vue';
 
@@ -87,9 +85,8 @@ import DiscoverySidebar from '@/components/organisms/sidebars/DiscoverySidebar.v
 import type { ManagementType } from '@/interfaces/exploration.ts';
 
 // Stores
-const canvasStore = useCanvasStore();
 const explorationStore = useExplorationStore();
-const { loadExplorationData } = useProjectExploration();
+const { currentProjectId, loadExplorationData } = useProjectExploration();
 
 const {
   registryNodes,

--- a/src/composables/useCanvasDrop.ts
+++ b/src/composables/useCanvasDrop.ts
@@ -1,19 +1,19 @@
 /**
- * useCanvasDrop.ts
- * Manages the orchestration of external items being dragged onto the workspace.
+ * @file useCanvasDrop.ts
+ * @description Statefully managed Drag-and-Drop Bridge for Vue Flow.
+ * Merges cross-boundary streaming tunnels into a zero-side-effect reactive interface,
+ * completely decoupled from DOM listeners and page stores.
  */
-import { inject } from 'vue';
+import { ref, inject } from 'vue';
 import type { ConceptualNode } from '@/interfaces/conceptual-map';
 import { useVueFlow } from '@vue-flow/core';
 import { ConceptualMapContextKey } from '@/constants/injection-keys';
 
-export function useCanvasDrop() {
-  const context = inject(ConceptualMapContextKey);
-  if (!context) {
-    throw new Error(
-      '[Architectural Violation] useCanvasDrop must be invoked within the subtree of a <ConceptualMapCanvas>.'
-    );
-  }
+const tunnelDraggedNode = ref<ConceptualNode | null>(null);
+const isTunnelDragging = ref(false);
+
+export function useCanvasDrop(explicitContext?: any) {
+  const context = explicitContext || inject(ConceptualMapContextKey, null);
 
   const { addNodes, screenToFlowCoordinate, onNodesInitialized, updateNode } = useVueFlow()
 
@@ -23,14 +23,23 @@ export function useCanvasDrop() {
       event.dataTransfer.effectAllowed = 'move'
     }
 
-    context.isDragging.value = true;
-    context.draggedNode.value = node;
-    document.addEventListener('drop', onDragEnd)
+    tunnelDraggedNode.value = node;
+    isTunnelDragging.value = true;
+
+    if (context) {
+      context.isDragging.value = true;
+      context.draggedNode.value = node;
+    }
   };
 
   const onDragOver = (event: DragEvent) => {
     event.preventDefault(); // Required to allow drop
+    if (!context) return;
+
     if (!context.isDragOver.value) context.isDragOver.value = true;
+
+    context.isDragging.value = isTunnelDragging.value;
+    context.draggedNode.value = tunnelDraggedNode.value;
 
     if (event.dataTransfer && event.dataTransfer.dropEffect !== 'move') {
       event.dataTransfer.dropEffect = 'move';
@@ -38,25 +47,35 @@ export function useCanvasDrop() {
   };
 
   const onDragLeave = (event: DragEvent) => {
-    context.isDragOver.value = false;
+    if (context) context.isDragOver.value = false;
   };
 
   const onDragEnd = () => {
-    context.isDragging.value = false;
-    context.isDragOver.value = false;
-    context.draggedNode.value = null;
-    document.removeEventListener('drop', onDragEnd)
+    tunnelDraggedNode.value = null;
+    isTunnelDragging.value = false;
+
+    if (context) {
+      context.isDragging.value = false;
+      context.isDragOver.value = false;
+      context.draggedNode.value = null;
+    }
   };
 
   const onDrop = (event: DragEvent) => {
-    if (context.draggedNode.value === null) return;
+    event.preventDefault();
+
+    let node = tunnelDraggedNode.value;
+    if (!node) {
+      const rawData = event.dataTransfer?.getData('application/vueflow');
+      if (rawData) node = JSON.parse(rawData);
+    }
+
+    if (!node || !context) return;
 
     const position = screenToFlowCoordinate({
       x: event.clientX,
       y: event.clientY,
     })
-
-    const node = context.draggedNode.value;
 
     const newNode = {
       id: node?.id,

--- a/src/composables/useCanvasDrop.ts
+++ b/src/composables/useCanvasDrop.ts
@@ -2,12 +2,18 @@
  * useCanvasDrop.ts
  * Manages the orchestration of external items being dragged onto the workspace.
  */
+import { inject } from 'vue';
 import type { ConceptualNode } from '@/interfaces/conceptual-map';
 import { useVueFlow } from '@vue-flow/core';
-import { useCanvasStore } from '@/stores/canvas';
+import { ConceptualMapContextKey } from '@/constants/injection-keys';
 
 export function useCanvasDrop() {
-  const store = useCanvasStore();
+  const context = inject(ConceptualMapContextKey);
+  if (!context) {
+    throw new Error(
+      '[Architectural Violation] useCanvasDrop must be invoked within the subtree of a <ConceptualMapCanvas>.'
+    );
+  }
 
   const { addNodes, screenToFlowCoordinate, onNodesInitialized, updateNode } = useVueFlow()
 
@@ -17,40 +23,40 @@ export function useCanvasDrop() {
       event.dataTransfer.effectAllowed = 'move'
     }
 
-    store.isDragging = true;
-    store.draggedNode = node;
+    context.isDragging.value = true;
+    context.draggedNode.value = node;
     document.addEventListener('drop', onDragEnd)
   };
 
   const onDragOver = (event: DragEvent) => {
     event.preventDefault(); // Required to allow drop
-    if (!store.isDragOver) store.isDragOver = true;
+    if (!context.isDragOver.value) context.isDragOver.value = true;
 
-    if (event.dataTransfer) {
+    if (event.dataTransfer && event.dataTransfer.dropEffect !== 'move') {
       event.dataTransfer.dropEffect = 'move';
     }
   };
 
   const onDragLeave = (event: DragEvent) => {
-    store.isDragOver = false;
+    context.isDragOver.value = false;
   };
 
   const onDragEnd = () => {
-    store.isDragging = false;
-    store.isDragOver = false;
-    store.draggedNode = null;
+    context.isDragging.value = false;
+    context.isDragOver.value = false;
+    context.draggedNode.value = null;
     document.removeEventListener('drop', onDragEnd)
   };
 
   const onDrop = (event: DragEvent) => {
-    if (store.draggedNode === null) return;
+    if (context.draggedNode.value === null) return;
 
     const position = screenToFlowCoordinate({
       x: event.clientX,
       y: event.clientY,
     })
 
-    const node = store.draggedNode;
+    const node = context.draggedNode.value;
 
     const newNode = {
       id: node?.id,

--- a/src/composables/useConceptualMapContext.ts
+++ b/src/composables/useConceptualMapContext.ts
@@ -15,11 +15,12 @@ import { POSITION_SCALE } from '@/constants/canvases';
 import { apiService } from '@/api/apiService';
 
 interface ContextConfig {
+  getCanvasId?: () => ID;
   getProjectId?: () => ID;
   getRegistryCount?: () => number;
 }
 
-export function useConceptualMapContext(canvasId: string, config?: ContextConfig) {
+export function useConceptualMapContext(config?: ContextConfig) {
   const canvasStore = useCanvasStore();
 
   // --------------------------------------------------------------------------
@@ -64,6 +65,12 @@ export function useConceptualMapContext(canvasId: string, config?: ContextConfig
    * Primary Entry Point: Load data from Cache or fallback to remote API
    */
   const fetchGraphData = async () => {
+    const canvasId = config?.getCanvasId ? config.getCanvasId() : null;
+    if (!canvasId) {
+      console.log('[Context API Warning] Missing canvas ID in configuration. Edge update aborted.');
+      return;
+    }
+
     // Step 1: Check global Pinia archive
     let graphData = canvasStore.getGraphCache(canvasId);
 
@@ -102,6 +109,12 @@ export function useConceptualMapContext(canvasId: string, config?: ContextConfig
    * Internal Helper: Commits local scoped mutations back into the cold store backup map
    */
   const syncBackToGlobalCache = () => {
+    const canvasId = config?.getCanvasId ? config.getCanvasId() : null;
+    if (!canvasId) {
+      console.log('[Context API Warning] Missing canvas ID in configuration. Edge update aborted.');
+      return;
+    }
+
     const rawNodesRecord: Map<string, ConceptualNode> = new Map();
 
     // Scale down back to storage baseline coordinates before backup
@@ -149,6 +162,12 @@ export function useConceptualMapContext(canvasId: string, config?: ContextConfig
    * Cleans up redundant 'push' actions from previous store bugs.
    */
   const updateConceptualMapEdge = async (edge: ConceptualEdge, action: 'create' | 'delete' | 'update') => {
+    const canvasId = config?.getCanvasId ? config.getCanvasId() : null;
+    if (!canvasId) {
+      console.log('[Context API Warning] Missing canvas ID in configuration. Edge update aborted.');
+      return;
+    }
+
     try {
       if (action === 'update') {
         const existingIndex = conceptualEdges.value.findIndex(e => e.id === edge.id);
@@ -178,9 +197,10 @@ export function useConceptualMapContext(canvasId: string, config?: ContextConfig
 
     const currentSandboxSize = conceptualNodes.size;
     const projectId = config?.getProjectId ? config.getProjectId() : null;
+    const canvasId = config?.getCanvasId ? config.getCanvasId() : null;
     const maxRegistryCount = config?.getRegistryCount ? config.getRegistryCount() : Infinity;
 
-    if (projectId && aiSuggestedNodes.length < 1 && currentSandboxSize < maxRegistryCount) {
+    if (projectId && canvasId && aiSuggestedNodes.length < 1 && currentSandboxSize < maxRegistryCount) {
       try {
         apiService.projects.exploration.recommendConceptualNodes(projectId, canvasId);
       } catch (error) {

--- a/src/composables/useConceptualMapContext.ts
+++ b/src/composables/useConceptualMapContext.ts
@@ -1,0 +1,263 @@
+/**
+ * @file useConceptualMapContext.ts
+ * @description Scoped State Holder for the Conceptual Map Canvas.
+ * Encapsulates high-frequency UI states (dragging, viewport) and temporary form caches
+ * to prevent global Pinia reactive hijacking and ensure synchronized garbage collection.
+ */
+
+import { ref, reactive, computed } from 'vue';
+import { v4 as uuidv4 } from 'uuid';
+import type { ID } from '@/interfaces/core';
+import type { Connection } from '@vue-flow/core';
+import type { ConceptualNode, ConceptualEdge, ConceptualGraph } from '@/interfaces/conceptual-map';
+import { useCanvasStore } from '@/stores/canvas';
+import { POSITION_SCALE } from '@/constants/canvases';
+import { apiService } from '@/api/apiService';
+
+interface ContextConfig {
+  getProjectId?: () => ID;
+  getRegistryCount?: () => number;
+}
+
+export function useConceptualMapContext(canvasId: string, config?: ContextConfig) {
+  const canvasStore = useCanvasStore();
+
+  // --------------------------------------------------------------------------
+  // 1. Core Graph Data States (Scoped)
+  // --------------------------------------------------------------------------
+  const conceptualNodes = reactive(new Map<string, ConceptualNode>());
+  const conceptualEdges = ref<ConceptualEdge[]>([]);
+
+  // --------------------------------------------------------------------------
+  // 2. High-Frequency Drag & Drop UI States
+  // --------------------------------------------------------------------------
+  const isDragging = ref(false);
+  const isDragOver = ref(false);
+  const draggedNode = ref<ConceptualNode | null>(null);
+  const viewport = reactive({ x: 0, y: 0, zoom: 1 });
+
+  // --------------------------------------------------------------------------
+  // 3. Low-Frequency Connection Interceptor Form States
+  // --------------------------------------------------------------------------
+  const isInterceptionActive = ref(false);
+  const interceptorAction = ref<'create' | 'update'>('create');
+  const interceptorPosition = reactive({ x: 0, y: 0 });
+  const pendingConnection = ref<Connection | null>(null);
+
+  const localEdgeData = ref<ConceptualEdge>({
+    id: uuidv4(),
+    label: '',
+    type: 'REF',
+    evidence: '',
+    weight: 1.0,
+    source: '',
+    sourceHandle: '',
+    target: '',
+    targetHandle: '',
+  });
+
+  // --------------------------------------------------------------------------
+  // B. Cache Orchestration Pipeline
+  // --------------------------------------------------------------------------
+
+  /**
+   * Primary Entry Point: Load data from Cache or fallback to remote API
+   */
+  const fetchGraphData = async () => {
+    // Step 1: Check global Pinia archive
+    let graphData = canvasStore.getGraphCache(canvasId);
+
+    if (!graphData) {
+      // Step 2: Cache Miss -> Trigger network request via store
+      graphData = await canvasStore.fetchAndCacheGraph(canvasId);
+    }
+
+    // Step 3: Populate local sandbox using the cold dataset
+    initializeSandbox(graphData);
+  };
+
+  /**
+   * Clones and scales cold storage snapshots into localized reactive variables
+   */
+  const initializeSandbox = (graph: ConceptualGraph) => {
+    conceptualNodes.clear();
+
+    // Deep copy objects to insulate runtime mutations from contaminating cold storage coordinates
+    Object.entries(graph.nodes).forEach(([key, value]) => {
+      const sourcePosition = value.position || { x: 0, y: 0 };
+      const clonedNode = {
+        ...value,
+        position: {
+          x: sourcePosition.x * POSITION_SCALE,
+          y: sourcePosition.y * POSITION_SCALE,
+        }
+      };
+      conceptualNodes.set(key, clonedNode);
+    });
+
+    conceptualEdges.value = [...graph.edges];
+  };
+
+  /**
+   * Internal Helper: Commits local scoped mutations back into the cold store backup map
+   */
+  const syncBackToGlobalCache = () => {
+    const rawNodesRecord: Map<string, ConceptualNode> = new Map();
+
+    // Scale down back to storage baseline coordinates before backup
+    conceptualNodes.forEach((node, key) => {
+      const nodePosition = node.position || { x: 0, y: 0 };
+      rawNodesRecord.set(key, {
+        ...node,
+        position: {
+          x: nodePosition.x / POSITION_SCALE,
+          y: nodePosition.y / POSITION_SCALE
+        }
+      });
+    });
+
+    canvasStore.updateCacheSnapshot(canvasId, {
+      nodes: rawNodesRecord,
+      edges: [...conceptualEdges.value]
+    });
+  };
+
+  // --------------------------------------------------------------------------
+  // C. Local Mutations & Persistence Engine
+  // --------------------------------------------------------------------------
+
+  /**
+   * Dispatches node updates including moving, editing, or structural deletes.
+   */
+  const updateConceptualMapNode = async (node: ConceptualNode, action: 'move' | 'link' | 'edit' | 'delete' | 'group') => {
+    if (action === 'delete') {
+      conceptualNodes.delete(node.id);
+      // Cascade delete associated edges to prevent dangling connections
+      conceptualEdges.value = conceptualEdges.value.filter(e => e.source !== node.id && e.target !== node.id);
+    } else if (action === 'group') {
+      // TODO: Implement group node logic
+    } else {
+      conceptualNodes.set(node.id, node);
+    }
+
+  // Synchronize local change to global store layer for fast tabs toggling
+    syncBackToGlobalCache();
+  };
+
+  /**
+   * Coordinates Edge persistence with backend API and updates local scoped state.
+   * Cleans up redundant 'push' actions from previous store bugs.
+   */
+  const updateConceptualMapEdge = async (edge: ConceptualEdge, action: 'create' | 'delete' | 'update') => {
+    try {
+      if (action === 'update') {
+        const existingIndex = conceptualEdges.value.findIndex(e => e.id === edge.id);
+        if (existingIndex !== -1) {
+          const response = await apiService.canvases.edges.update(canvasId, edge.id, edge);
+          conceptualEdges.value[existingIndex] = response.data || edge;
+        }
+      } else if (action === 'create') {
+        const response = await apiService.canvases.edges.create(canvasId, edge);
+        conceptualEdges.value.push(response.data || edge);
+      } else if (action === 'delete') {
+        await apiService.canvases.edges.delete(canvasId, edge.id);
+        conceptualEdges.value = conceptualEdges.value.filter(e => e.id !== edge.id);
+      }
+
+      // Synchronize local change to global store layer for fast tabs toggling
+      syncBackToGlobalCache();
+    } catch (error) {
+      console.error(`[Context API Error] Failed to ${action} edge:`, error);
+      throw error; // Propagate to let UI handle error states if necessary
+    }
+  };
+
+  const recommendConceptualNodes = async () => {
+    const aiSuggestedNodes = Array.from(conceptualNodes.values())
+      .filter(node => node.status === 'AI_EXTRACTED');
+
+    const currentSandboxSize = conceptualNodes.size;
+    const projectId = config?.getProjectId ? config.getProjectId() : null;
+    const maxRegistryCount = config?.getRegistryCount ? config.getRegistryCount() : Infinity;
+
+    if (projectId && aiSuggestedNodes.length < 1 && currentSandboxSize < maxRegistryCount) {
+      try {
+        apiService.projects.exploration.recommendConceptualNodes(projectId, canvasId);
+      } catch (error) {
+        console.error('[AI Recommendation Error]', error);
+      }
+    }
+  };
+
+  // --------------------------------------------------------------------------
+  // 5. UI Interactivity Actions
+  // --------------------------------------------------------------------------
+  const setDragStatus = (status: { isDragging?: boolean; isDragOver?: boolean }) => {
+    if (status.isDragging !== undefined) isDragging.value = status.isDragging;
+    if (status.isDragOver !== undefined) isDragOver.value = status.isDragOver;
+  };
+
+  const openInterceptor = (connection: Connection | null, position: { x: number; y: number }, existingEdge?: ConceptualEdge) => {
+    isInterceptionActive.value = true;
+    pendingConnection.value = connection;
+    interceptorPosition.x = position.x;
+    interceptorPosition.y = position.y;
+
+    if (existingEdge) {
+      interceptorAction.value = 'update';
+      localEdgeData.value = { ...existingEdge };
+    } else if (connection) {
+      interceptorAction.value = 'create';
+      localEdgeData.value = {
+        id: uuidv4(),
+        label: '',
+        type: 'REF',
+        evidence: '',
+        weight: 1.0,
+        source: connection.source,
+        sourceHandle: connection.sourceHandle || '',
+        target: connection.target,
+        targetHandle: connection.targetHandle || '',
+      };
+    } else {
+      closeInterceptor();
+    }
+  };
+
+  const closeInterceptor = () => {
+    isInterceptionActive.value = false;
+    pendingConnection.value = null;
+  };
+
+  const updateLocalEdgeData = (patch: Partial<ConceptualEdge>) => {
+    localEdgeData.value = { ...localEdgeData.value, ...patch };
+  };
+
+  // --------------------------------------------------------------------------
+  // 6. Return Payload
+  // --------------------------------------------------------------------------
+  return {
+    // Reactive States (Leaf components grab references directly)
+    conceptualNodes,
+    conceptualEdges,
+    isDragging,
+    isDragOver,
+    draggedNode,
+    viewport,
+    isInterceptionActive,
+    interceptorAction,
+    interceptorPosition,
+    pendingConnection,
+    localEdgeData,
+
+    // Actions
+    fetchGraphData,
+    updateConceptualMapNode,
+    updateConceptualMapEdge,
+    setDragStatus,
+    openInterceptor,
+    closeInterceptor,
+    updateLocalEdgeData,
+    recommendConceptualNodes
+  };
+}

--- a/src/composables/useEdgeInterceptor.ts
+++ b/src/composables/useEdgeInterceptor.ts
@@ -1,13 +1,20 @@
 /**
  * useEdgeInterceptor.ts
  * Controller Module: Intercepts raw connection events to collect semantic metadata.
+ * Refactored to utilize Scoped Component Context to eliminate lifecycle leaks and memory staleness.
  */
+import { inject } from 'vue';
 import type { ConceptualNode, ConceptualEdge, EdgeType } from '@/interfaces/conceptual-map';
-import { useCanvasStore } from '@/stores/canvas';
 import type { Connection } from '@vue-flow/core';
+import { ConceptualMapContextKey } from '@/constants/injection-keys';
 
 export function useEdgeInterceptor() {
-  const store = useCanvasStore();
+  const context = inject(ConceptualMapContextKey);
+  if (!context) {
+    throw new Error(
+      '[Architectural Violation] useEdgeInterceptor must be invoked within the subtree of a <ConceptualMapCanvas>.'
+    );
+  }
 
   /**
    * Internal Utility: getEdgeMidpoint
@@ -37,36 +44,40 @@ export function useEdgeInterceptor() {
   const startInterception = (connection: Connection, nodes: Map<string, ConceptualNode>) => {
     const midpoint = calculateMidpoint(connection, nodes);
 
-    // Prevent immediate creation
-    store.setInterceptionActivity(true);
-    store.openInterceptor(connection, midpoint);
+    // Prevent immediate graph insertion; open the scoped contextual input form instead
+    context.openInterceptor(connection, midpoint);
   };
 
   /**
    * Phase 2: ASSEMBLE_PAYLOAD & COMMIT_TO_STORE
    * Finalizes the data structure and sends it to the store.
    */
-  const confirmRelation = () => {
-    if (!store.current?.pendingConnection && store.current?.interceptorAction == 'create') return;
+  const confirmRelation = async () => {
+    if (!context.pendingConnection.value && context.interceptorAction.value == 'create') return;
 
     const newEdge: ConceptualEdge = {
-      ...store.current?.localEdgeData!,
+      ...context.localEdgeData.value,
     };
 
-    // Dispatch to store action
-    if (store.current?.interceptorAction == 'create') {
-      store.updateConceptualMapEdge(newEdge, 'create');
-    } else if (store.current?.interceptorAction == 'update') {
-      store.updateConceptualMapEdge(newEdge, 'update');
-    }
+    try {
+      // Dispatch to store action
+      await context.updateConceptualMapEdge(newEdge, context.interceptorAction.value);
 
-    // Clean up
-    store.closeInterceptor();
+      // Clean up
+      context.closeInterceptor();
+    } catch(error) {
+      console.error('[Interceptor Flow Error] Aborted edge persistence:', error);
+    }
+  };
+
+  const cancelRelation = () => {
+    context.closeInterceptor();
   };
 
   return {
     // Actions
     startInterception,
     confirmRelation,
+    cancelRelation
   };
 }

--- a/src/composables/useEdgeInterceptor.ts
+++ b/src/composables/useEdgeInterceptor.ts
@@ -8,8 +8,8 @@ import type { ConceptualNode, ConceptualEdge, EdgeType } from '@/interfaces/conc
 import type { Connection } from '@vue-flow/core';
 import { ConceptualMapContextKey } from '@/constants/injection-keys';
 
-export function useEdgeInterceptor() {
-  const context = inject(ConceptualMapContextKey);
+export function useEdgeInterceptor(explicitContext?: any) {
+  const context = explicitContext || inject(ConceptualMapContextKey, null);
   if (!context) {
     throw new Error(
       '[Architectural Violation] useEdgeInterceptor must be invoked within the subtree of a <ConceptualMapCanvas>.'
@@ -74,10 +74,17 @@ export function useEdgeInterceptor() {
     context.closeInterceptor();
   };
 
+  const deleteRelation = () => {
+    context.updateConceptualMapEdge(context!.localEdgeData.value, 'delete');
+    context.closeInterceptor();
+  };
+
   return {
+    context,
     // Actions
     startInterception,
     confirmRelation,
-    cancelRelation
+    cancelRelation,
+    deleteRelation,
   };
 }

--- a/src/composables/useProjectExploration.ts
+++ b/src/composables/useProjectExploration.ts
@@ -1,15 +1,11 @@
 import { apiService } from '@/api/apiService';
-import { POSITION_SCALE } from '@/constants/canvases';
-import { ConceptualNode } from '@/interfaces/conceptual-map';
 import { ID } from '@/interfaces/core';
-import { useCanvasStore } from '@/stores/canvas';
 import { useExplorationStore } from '@/stores/exploration';
 import { useProjectStore } from '@/stores/project';
 import { computed } from 'vue';
 import { useRoute } from 'vue-router';
 
 export function useProjectExploration() {
-  const canvasStore = useCanvasStore();
   const explorationStore = useExplorationStore();
   const projectStore = useProjectStore();
   const route = useRoute();
@@ -18,10 +14,6 @@ export function useProjectExploration() {
     return route.params.id as ID || projectStore.currentProjectId || '';
   });
 
-  const activeCanvasId = computed(() => explorationStore.activeCanvasId);
-  const conceptualNodes = computed(() => canvasStore.current?.conceptualNodes ?? new Map());
-  const sidebarNodes = computed(() => explorationStore.sidebarNodes);
-
   async function loadExplorationData() {
     if (projectStore.currentProjectId === null) {
       projectStore.setCurrentProjectId(route.params.id as ID);
@@ -29,7 +21,6 @@ export function useProjectExploration() {
 
     try {
       await loadSidebarRegistryInfo();
-      await loadCanvasView();
       if (projectStore.currentStage !== 'EXPLORATION') {
         await projectStore.updateProjectDetail(projectStore.currentProjectId as ID, {currentStage: 'EXPLORATION'})
       } else {
@@ -53,53 +44,8 @@ export function useProjectExploration() {
     }
   };
 
-  async function loadCanvasView() {
-    try {
-      let response = await apiService.canvases.graphs.get(activeCanvasId.value);
-      if (response.data) {
-        await canvasStore.mountCanvas(activeCanvasId.value);
-        canvasStore.setConceptualGraph(response.data)
-      } else {
-        console.log(response.data);
-      }
-    } catch (error) {
-      console.error('Failed to load exploration data:', error);
-    }
-  };
-
-  async function recommendConceptualNodes() {
-    let aiSuggestedNodes = [...conceptualNodes.value.values()].filter(node => node.status === 'AI_EXTRACTED');
-    if (aiSuggestedNodes.length < 1 && conceptualNodes.value.size < sidebarNodes.value.size) {
-      apiService.projects.exploration.recommendConceptualNodes(currentProjectId.value, activeCanvasId.value);
-    }
-  };
-
-  async function updateConeptualNode(node: ConceptualNode) {
-    try {
-      let nodeData = JSON.parse(JSON.stringify(node));
-      if (nodeData.position) {
-        nodeData.position.x /= POSITION_SCALE;
-        nodeData.position.y /= POSITION_SCALE;
-      }
-
-      let response = await apiService.canvases.nodes.update(activeCanvasId.value, nodeData.id, nodeData);
-      if (response.data) {
-        let newNode = response.data;
-        if (newNode.position) {
-          newNode.position.x *= POSITION_SCALE;
-          newNode.position.y *= POSITION_SCALE;
-        }
-
-        canvasStore.current?.conceptualNodes.set(newNode.id, newNode);
-        recommendConceptualNodes();
-      }
-    } catch (error) {
-      console.error('Failed to update node:', error);
-    }
-  };
-
   return {
+    currentProjectId,
     loadExplorationData,
-    updateConeptualNode,
   };
 };

--- a/src/constants/injection-keys.ts
+++ b/src/constants/injection-keys.ts
@@ -1,0 +1,31 @@
+/**
+ * @file injection-keys.ts
+ * @description Centralized repository for Vue Injection Keys within the conceptual map domain.
+ * This file acts as an architectural breakwater to prevent circular dependency chains
+ * (e.g., CanvasRoot -> Composable -> CanvasRoot) and enforces compile-time type safety
+ * for the Provide/Inject reactive context.
+ */
+
+import type { InjectionKey } from 'vue';
+import type { useConceptualMapContext } from '@/composables/useConceptualMapContext';
+
+/**
+ * Type inferred directly from the return value of the scoped context composable.
+ * This guarantees that any changes to the reactive state structure in the composable
+ * will automatically propagate to all consumer components injecting this key.
+ */
+export type ConceptualMapContextType = ReturnType<typeof useConceptualMapContext>;
+
+/**
+ * InjectionKey for the scoped canvas context.
+ * Mandated for use within the root `ConceptualMapCanvas.vue` (Provider)
+ * and downstream hooks/components like `useCanvasDrop.ts` and `useEdgeInterceptor.ts` (Consumers).
+ *
+ * @example
+ * // Provider (Root)
+ * provide(ConceptualMapContextKey, canvasContext);
+ *
+ * // Consumer (Hooks/Leaf Components)
+ * const context = inject(ConceptualMapContextKey);
+ */
+export const ConceptualMapContextKey = Symbol('ConceptualMapContext') as InjectionKey<ConceptualMapContextType>;

--- a/src/stores/canvas.ts
+++ b/src/stores/canvas.ts
@@ -1,165 +1,56 @@
-import { apiService } from '@/api/apiService';
-import { POSITION_SCALE } from '@/constants/canvases';
-import type { CanvasViewInstance, ConceptualEdge, ConceptualGraph, ConceptualNode, EdgeType } from '@/interfaces/conceptual-map';
-import type { Connection } from '@vue-flow/core';
+/**
+ * @file canvas.ts (Pinia Store)
+ * @description Transformed into a pure passive Data Cache Layer.
+ * Holds cold graph snapshots in memory to prevent redundant HTTP requests during page toggles,
+ * completely decoupled from Vue Flow high-frequency reactive rendering loops.
+ */
 import { defineStore } from 'pinia';
-import { v4 as uuidv4 } from 'uuid';
+import { apiService } from '@/api/apiService';
+import type { ConceptualGraph } from '@/interfaces/conceptual-map';
 
 export const useCanvasStore = defineStore('canvas', {
   state: () => ({
-    instances: new Map<string, CanvasViewInstance>(),
-    activeCanvasId: '',
+    // Use a primitive Map to store immutable data cache snapshots
+    graphCacheRepository: new Map<string, ConceptualGraph>(),
   }),
 
-	getters: {
-    current: (state) => state.instances.get(state.activeCanvasId),
-  },
-
   actions: {
-    async mountCanvas(id: string) {
-      this.activeCanvasId = id;
+    /**
+     * Cache Reader
+     */
+    getGraphCache(id: string): ConceptualGraph | undefined {
+      return this.graphCacheRepository.get(id);
+    },
 
-      if (!this.instances.has(id)) {
-        this.instances.set(id, {
-          conceptualNodes: new Map(),
-          conceptualEdges: [],
-          isInterceptionActive: false,
-          interceptorAction: 'create',
-          interceptorPosition: { x: 0, y: 0 },
-          pendingConnection: null,
-          localEdgeData: {
-            id: uuidv4(),
-            label: '',
-            type: 'REF',
-            evidence: '',
-            weight: 1.0,
-            source: '',
-            sourceHandle: '',
-            target: '',
-            targetHandle: '',
-          },
-              // --- Drag & Drop UI State ---
-          isDragging: false,
-          isDragOver: false,
-          draggedNode: null as any | null,
-          viewport: { x: 0, y: 0, zoom: 1 }
-        });
+    /**
+     * Cache Server: Fetches from backend API on cache-miss and commits to memory
+     */
+    async fetchAndCacheGraph(id: string): Promise<ConceptualGraph> {
+      try {
+        const response = await apiService.canvases.graphs.get(id);
+        const graphData = response.data || { nodes: {}, edges: [] };
+
+        // Write cold data into global storage repository
+        this.graphCacheRepository.set(id, graphData);
+        return graphData;
+      } catch (error) {
+        console.error(`[Pinia Cache System Error] Failed to load canvas ${id}:`, error);
+        throw error;
       }
     },
 
-    unmountCanvas(id: string) {
-      this.instances.delete(id);
+    /**
+     * Direct Cache Mutator: Updates the cold storage snapshot when context persists changes
+     */
+    updateCacheSnapshot(id: string, graph: ConceptualGraph) {
+      this.graphCacheRepository.set(id, graph);
     },
 
-    async setConceptualGraph(graph: ConceptualGraph) {
-      if (!this.current) return;
-
-      Object.entries(graph.nodes).map(([key, value]) => {
-        value.position.x *= POSITION_SCALE;
-        value.position.y *= POSITION_SCALE;
-        this.current?.conceptualNodes.set(key, value);
-      });
-
-      this.current.conceptualEdges = graph.edges;
-    },
-
-    openInterceptor(connection: Connection | null, position: { x: number; y: number }, existingEdge?: ConceptualEdge) {
-      if (!this.current) return;
-
-      this.current.isInterceptionActive = true;
-      this.current.pendingConnection = connection;
-      this.current.interceptorPosition = position;
-
-      if (existingEdge) {
-        this.current.interceptorAction = 'update';
-        this.current.localEdgeData = { ...existingEdge };
-      } else if (connection) {
-        this.current.interceptorAction = 'create';
-        // Reset form
-        this.current.localEdgeData = {
-          id: uuidv4(),
-          label: '',
-          type: 'REF',
-          evidence: '',
-          weight: 1.0,
-          source: connection.source,
-          sourceHandle: connection.sourceHandle,
-          target: connection.target,
-          targetHandle: connection.targetHandle,
-        };
-      } else {
-        // TODO: Handle case where connection is null (e.g., manual open for editing)
-        this.closeInterceptor();
-      }
-    },
-
-    closeInterceptor() {
-      if (!this.current) return;
-
-      this.current.isInterceptionActive = false;
-      this.current.pendingConnection = null;
-    },
-
-    setInterceptionActivity(status: boolean) {
-      if (!this.current) return;
-
-      this.current.isInterceptionActive = status;
-    },
-
-    setDragStatus(status: { isDragging?: boolean; isDragOver?: boolean }) {
-      if (!this.current) return;
-
-      if (status.isDragging !== undefined) this.current.isDragging = status.isDragging;
-      if (status.isDragOver !== undefined) this.current.isDragOver = status.isDragOver;
-    },
-
-    /** Handles updates for existing nodes, including moving, grouping, and editing */
-    updateConceptualMapNode(node: ConceptualNode, action: 'move' | 'link' | 'edit' | 'delete' | 'group') {
-      if (!this.current) return;
-
-      if (action === 'delete') {
-        this.current.conceptualNodes.delete(node.id);
-        // Also delete related edges
-        this.current.conceptualEdges = this.current.conceptualEdges.filter(e => e.source !== node.id && e.target !== node.id);
-      } else if (action === 'group') {
-        // Logic to create or update a Group Node (U.S. 7)
-      } else {
-        this.current.conceptualNodes.set(node.id, node);
-      }
-    },
-
-    /** Handles edge creation, deletion, and label editing */
-    async updateConceptualMapEdge(edge: ConceptualEdge, action: 'create' | 'delete' | 'update') {
-      if (!this.current) return;
-
-      if (action === 'create' || action === 'update') {
-        const existingIndex = this.current.conceptualEdges.findIndex(e => e.id === edge.id);
-        if (existingIndex !== -1) {
-          let response = await apiService.canvases.edges.update(this.activeCanvasId, edge.id, edge);
-          if (response.data) {
-            this.current.conceptualEdges.push(response.data);
-          }
-          this.current.conceptualEdges[existingIndex] = edge;
-        } else if (action === 'create') {
-          let response = await apiService.canvases.edges.create(this.activeCanvasId, edge);
-          if (response.data) {
-            this.current.conceptualEdges.push(response.data);
-          }
-        }
-      } else if (action === 'delete') {
-        try {
-          await apiService.canvases.edges.delete(this.activeCanvasId, edge.id);
-          this.current.conceptualEdges = this.current.conceptualEdges.filter(e => e.id !== edge.id);
-        } catch (error) {
-          console.error('Failed!', error);
-        }
-      }
-    },
-
-    updateLocalEdgeData(patch: any) {
-      if (!this.current) return;
-
-      this.current.localEdgeData = { ...this.current.localEdgeData, ...patch };
-    },
+    /**
+     * Cache Invalidator: Forces a reload on next mount
+     */
+    invalidateCache(id: string) {
+      this.graphCacheRepository.delete(id);
+    }
   }
 });


### PR DESCRIPTION
This PR implements critical architectural refinements to the conceptual map canvas ecosystem. It resolves a runtime crash caused by Vue 3's self-injection boundaries, decouples cross-boundary drag-and-drop mechanics, and optimizes rendering performance by isolating transient UI interaction states away from the global store.

---

## 🚀 Key Changes

### 🏗️ Architectural Improvements

* **Decoupled State Management (Global vs. Scoped):** Migrated high-frequency reactive states (such as connection edge payloads, logical labels, and interceptor positions) out of the global Pinia store into a localized scoped context sandbox. The global store is now repurposed as a passive data cache layer, drastically reducing root-page component re-renders.
* **Dual-Track Context Overrides:** Refactored `useCanvasDrop` and `useEdgeInterceptor` to accept an optional explicit context parameter while seamlessly falling back to Vue’s `inject` mechanism. This circumvents runtime restrictions during synchronous layout setup phases where components cannot self-inject their own provided keys.
* **Lazy Value Evaluation:** Transformed the canvas state configuration to lazily evaluate the canvas ID via a functional hook (`getCanvasId`) rather than locking a static string eagerly. This safeguards data fetching against premature or stale reactivity cycles.

### 🐛 Bug Fixes & Interoperability

* **Fixed Drag-and-Drop Data Mismatch:** Updated the sidebar node tree handler to stringify and pass the full node object through the native HTML5 `dataTransfer` payload. This aligns with the newly rewritten canvas drop parser, eliminating runtime mismatches where only raw IDs were previously supplied.

---

## 🔍 Detailed Breakdown

### Scoped Context Sandbox vs. Pinia Data Layer

Previously, interactions such as dragging nodes or toggling edge configuration modals caused the global Pinia store to constantly emit updates. By trapping these transient changes in a localized context, we achieve:

* **Enhanced Modularity:** Pure UI elements like `VEdgeFloatingEditor` now interface with composable delegate methods (`cancelRelation`, `deleteRelation`) instead of raw global mutations.
* **Clean State Transitions:** Pinia now explicitly exposes a passive `updateCacheSnapshot` action, which is only invoked when state synchronization needs to be written to the cold cache backup map.

---

## 💡 Technical Decisions

### Explicit Override with Injection Fallback

Vue 3's core layout constraints make a component's own provided properties invisible to its immediate setup cycle. Rather than introducing complex asynchronous macro-tasks or micro-task delayed hooks, we chose a **"显式優先、隱式備援" (Explicit Priority with Fallback Injection)** pattern.

This enables the parent canvas container to pass its freshly instantiated context directly into the composables, while deeply nested downstream sub-components (like sidebars and floating overlays) can continue using empty-argument composable calls via implicit runtime injection.

---

## ⚠️ Migration Notes

* **Data Structure Change for Drag Events:** Any custom layout elements or third-party slots invoking drag actions targeting this canvas must now serialize the full `ConceptualNode` schema under the `application/vueflow` MIME type, instead of passing a singular raw ID string.
