### PR TITLE
UI Refactor: Scoped Floating Editors, Unified Quick Actions, and AI Lifecycle Workflows for Canvas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@vue-flow/controls": "^1.1.3",
         "@vue-flow/core": "^1.48.2",
         "@vue-flow/minimap": "^1.5.4",
+        "@vue-flow/node-toolbar": "^1.1.1",
         "axios": "^1.16.1",
         "bson": "^7.2.0",
         "date-fns": "^4.2.1",
@@ -1816,6 +1817,16 @@
         "d3-selection": "^3.0.0",
         "d3-zoom": "^3.0.0"
       },
+      "peerDependencies": {
+        "@vue-flow/core": "^1.23.0",
+        "vue": "^3.3.0"
+      }
+    },
+    "node_modules/@vue-flow/node-toolbar": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@vue-flow/node-toolbar/-/node-toolbar-1.1.1.tgz",
+      "integrity": "sha512-vgSnGMLd3FXstdpvC721qcBDzGkPsudmyA8urEP55/EMikCp59klgzPvVULTDxxsew5MdXtTBCumsqOi+PXJdg==",
+      "license": "MIT",
       "peerDependencies": {
         "@vue-flow/core": "^1.23.0",
         "vue": "^3.3.0"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@vue-flow/controls": "^1.1.3",
     "@vue-flow/core": "^1.48.2",
     "@vue-flow/minimap": "^1.5.4",
+    "@vue-flow/node-toolbar": "^1.1.1",
     "axios": "^1.16.1",
     "bson": "^7.2.0",
     "date-fns": "^4.2.1",

--- a/src/components/molecules/canvases/VEdgeFloatingEditor.vue
+++ b/src/components/molecules/canvases/VEdgeFloatingEditor.vue
@@ -7,15 +7,8 @@
       padding="md"
       rounded="lg"
       border="all"
-      class="w-72 shadow-xl animate-in fade-in zoom-in duration-200 nodrag nopan"
-      :style="{
-        position: 'absolute',
-        left: `${context.interceptorPosition.x}px`,
-        top: `${context.interceptorPosition.y}px`,
-        transform: 'translate(-50%, -50%)',
-        pointerEvents: 'all',
-        zIndex: 1000,
-      }"
+      class="w-72 shadow-xl animate-in fade-in zoom-in duration-200 nodrag nopan v-edge-floating-editor"
+      :style="editorStyle"
     >
       <VStack gap="md">
         <VCluster justify="between" align="center">
@@ -37,6 +30,7 @@
           <VSelect
             v-model="context.localEdgeData.value.type"
             size="sm"
+            class="w-full"
           >
             <option
               v-for="edgeType in edgeTypeOptions"
@@ -65,39 +59,32 @@
           />
         </VFormField>
 
-        <VCluster justify="end" gap="sm" class="pt-2">
+        <VEntityStatusActionGroup
+          :is-locked="isLocked"
+          :is-modified="isEdgeModified"
+          :disabled="!isValid"
+          :labels="{
+            unlockedHold: 'Save Draft',
+            unlockedPrimary: 'Lock Link',
+            unlockedPrimaryClass: 'bg-emerald-600! hover:bg-emerald-700!',
+            lockedHold: 'Put On Hold',
+            lockedPrimary: 'Save Changes'
+          }"
+          @cancel="close"
+          @submit="handleStateSubmit"
+        />
 
-          <VButton
-            v-if="context.interceptorAction.value === 'update'"
-            variant="danger"
-            size="sm"
-            @click="handleDelete"
-          >
-            Delete
-          </VButton>
-<!--
-          <VButton variant="ghost" size="sm" @click="close">
-            Cancel
-          </VButton>
- -->
-          <VButton variant="primary" size="sm" @click="confirmRelation">
-            {{ context.interceptorAction.value == 'create' ? 'Create' : 'Update' }} Link
-          </VButton>
-
-
-        </VCluster>
       </VStack>
     </VBox>
   </EdgeLabelRenderer>
 </template>
 
 <script setup lang="ts">
-import { inject } from 'vue';
-import { EdgeLabelRenderer } from '@vue-flow/core';
+import { computed } from 'vue';
+import { EdgeLabelRenderer, useVueFlow } from '@vue-flow/core'; // 🟢 Added useVueFlow
 import { useEdgeInterceptor } from '@/composables/useEdgeInterceptor';
-import { ConceptualMapContextKey } from '@/constants/injection-keys';
 
-// Atoms & Molecules (Assuming standard naming from your stack)
+// Atoms & Molecules Layout Imports
 import VBox from '@/components/atoms/layout/VBox.vue';
 import VStack from '@/components/atoms/layout/VStack.vue';
 import VCluster from '@/components/atoms/layout/VCluster.vue';
@@ -108,22 +95,20 @@ import VSelect from '@/components/atoms/forms/VSelect.vue';
 import VTextarea from '@/components/atoms/forms/VTextarea.vue';
 import VFormField from '@/components/molecules/forms/VFormField.vue';
 
-/**
- * VEdgeFloatingEditor Molecule
- * Provides a UI overlay to define semantic metadata when a new connection is initiated.
- * Integrated with useEdgeInterceptor for state management.
- */
+// Shared State Machine Action Component
+import VEntityStatusActionGroup from '@/components/molecules/domain/VEntityStatusActionGroup.vue';
+
 const {
   context,
   cancelRelation,
   confirmRelation,
-  deleteRelation,
 } = useEdgeInterceptor();
 
 /**
- * Options mapped to EdgeType for the select dropdown.
- * Aligned with Empirical Science standards in conceptual-map.ts.
+ * 🟢 Access the active VueFlow context to read reactive zoom levels
  */
+const { viewport } = useVueFlow();
+
 const edgeTypeOptions = [
   { label: 'Reference (Association)', value: 'REF' },
   { label: 'Validates (Support)', value: 'VALIDATES' },
@@ -132,31 +117,75 @@ const edgeTypeOptions = [
   { label: 'Structural Link', value: 'LINK' },
 ];
 
+// --- 🟢 Dynamic Layout Compensation Logic ---
+
+/**
+ * Computes exact inline styles applying an inverse viewport transform matrix.
+ * This guarantees the editor remains at 100% scale regardless of map coordinates.
+ */
+const editorStyle = computed(() => {
+  const currentZoom = viewport.value.zoom || 1;
+  const inverseScale = 1 / currentZoom;
+
+  return {
+    position: 'absolute' as const,
+    left: `${context.interceptorPosition.x}px`,
+    top: `${context.interceptorPosition.y}px`,
+    /* Combines alignment mapping with reciprocal viewport scale correction.
+      If zoom is 0.5, scale becomes 2.0 (canceling out canvas shrinkage).
+    */
+    transform: `translate(-50%, -50%) scale(${inverseScale})`,
+    transformOrigin: 'center center',
+    pointerEvents: 'all' as const,
+    zIndex: 1000,
+  };
+});
+
+// --- Computed State Layers ---
+const currentEdge = computed(() => {
+  const edgeId = context.intersectingEdgeId?.value;
+  if (!edgeId) return null;
+  return context.conceptualEdges.value.find((e: any) => e.id === edgeId);
+});
+
+const isLocked = computed(() => currentEdge.value?.status === 'LOCKED');
+const isValid = computed(() => true);
+
+const isEdgeModified = computed(() => {
+  if (!currentEdge.value) return false;
+  return (
+    context.localEdgeData.value.type !== currentEdge.value.type ||
+    (context.localEdgeData.value.label || '') !== (currentEdge.value.label || '') ||
+    (context.localEdgeData.value.evidence || '') !== (currentEdge.value.evidence || '')
+  );
+});
+
+// --- Action Delegations ---
 function close() {
   cancelRelation();
-};
+}
 
-function handleDelete() {
-  if (confirm('Delete this relationship?')) {
-    deleteRelation();
-  };
-};
-
+async function handleStateSubmit(targetStatus: 'LOCKED' | 'ON_HOLD' | 'USER_DRAFT') {
+  if (!isValid.value) return;
+  context.localEdgeData.value.status = targetStatus;
+  await confirmRelation();
+}
 </script>
 
 <style scoped>
-/* Ensure the editor doesn't get clipped by the canvas container */
 .v-edge-floating-editor {
   user-select: none;
 }
 
-/* Simple animation for appearance */
+/* Micro-interaction layer animations.
+  Note: Removed hardcoded transform definitions here to avoid fighting the inline script matrices.
+*/
 .animate-in {
   animation: fadeIn 0.15s ease-out;
 }
 
 @keyframes fadeIn {
-  from { opacity: 0; transform: translate(-50%, -45%) scale(0.95); }
-  to { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 </style>

--- a/src/components/molecules/canvases/VEdgeFloatingEditor.vue
+++ b/src/components/molecules/canvases/VEdgeFloatingEditor.vue
@@ -62,7 +62,7 @@
         <VEntityStatusActionGroup
           :is-locked="isLocked"
           :is-modified="isEdgeModified"
-          :disabled="!isValid"
+          :disabled="false"
           :labels="{
             unlockedHold: 'Save Draft',
             unlockedPrimary: 'Lock Link',
@@ -149,7 +149,6 @@ const currentEdge = computed(() => {
 });
 
 const isLocked = computed(() => currentEdge.value?.status === 'LOCKED');
-const isValid = computed(() => true);
 
 const isEdgeModified = computed(() => {
   if (!currentEdge.value) return false;
@@ -166,7 +165,6 @@ function close() {
 }
 
 async function handleStateSubmit(targetStatus: 'LOCKED' | 'ON_HOLD' | 'USER_DRAFT') {
-  if (!isValid.value) return;
   context.localEdgeData.value.status = targetStatus;
   await confirmRelation();
 }

--- a/src/components/molecules/canvases/VEntityCanvasQuickActions.vue
+++ b/src/components/molecules/canvases/VEntityCanvasQuickActions.vue
@@ -1,0 +1,90 @@
+<template>
+  <VCluster gap="xs" align="center" class="bg-white p-1.5 rounded-lg shadow-lg border border-slate-200 backdrop-blur-sm select-none">
+
+    <template v-if="props.status === 'AI_EXTRACTED'">
+      <VButton
+        variant="ghost"
+        size="xs"
+        class="text-rose-600 hover:bg-rose-50!"
+        icon-name="XMark"
+        title="'Reject & Discard'"
+        @click="emit('action', 'REJECT')"
+      >
+        Reject
+      </VButton>
+
+      <VButton
+        variant="primary"
+        size="xs"
+        class="bg-emerald-600! hover:bg-emerald-700!"
+        icon-name="Check"
+        title="'Accept & Verify'"
+        @click="emit('action', 'ACCEPT')"
+      >
+        Accept
+      </VButton>
+    </template>
+
+    <template v-else>
+      <VButton
+        v-if="props.status !== 'ON_HOLD'"
+        variant="ghost"
+        size="xs"
+        class="text-slate-600"
+        icon-name="ArchiveBox"
+        title="'Put On Hold'"
+        @click="emit('action', 'HOLD')"
+      />
+      <VButton
+        v-else
+        variant="ghost"
+        size="xs"
+        class="text-indigo-600 hover:bg-indigo-50!"
+        icon-name="LockOpen"
+        title="'Unlock to Draft'"
+        @click="emit('action', 'DRAFT')"
+      />
+
+      <VButton
+        v-if="props.status !== 'LOCKED'"
+        variant="ghost"
+        size="xs"
+        class="text-slate-600 hover:text-emerald-600!"
+        icon-name="LockClosed"
+        title="'Lock Strategy'"
+        @click="emit('action', 'LOCK')"
+      />
+
+      <div class="h-4 w-px bg-slate-200 mx-1" />
+
+      <VButton
+        variant="ghost"
+        size="xs"
+        class="text-slate-400 hover:text-red-600! hover:bg-red-50!"
+        icon-name="Trash"
+        title="'Delete Permanently'"
+        @click="emit('action', 'DELETE')"
+      />
+    </template>
+
+  </VCluster>
+</template>
+
+<script setup lang="ts">
+import type { EntityActionType } from '@/interfaces/core';
+
+import VCluster from '@/components/atoms/layout/VCluster.vue';
+import VButton from '@/components/atoms/buttons/VButton.vue';
+
+/**
+ * Available atomic event triggers dispatched directly on single-click streams.
+ */
+
+const props = defineProps<{
+  status: string | undefined; // Current business pipeline state (AI_EXTRACTED, USER_DRAFT, LOCKED, ON_HOLD)
+}>();
+
+const emit = defineEmits<{
+  (e: 'action', type: EntityActionType): void;
+}>();
+</script>

--- a/src/components/molecules/canvases/VNodeActionGroup.vue
+++ b/src/components/molecules/canvases/VNodeActionGroup.vue
@@ -8,52 +8,68 @@
     @click.stop
   >
     <VCluster gap="xs" align="center">
-      <VButton
-        variant="primary"
-        size="xs"
-        class="bg-emerald-600! hover:bg-emerald-700!"
-        @click="emit('accept')"
-      >
-        ACCEPT
-      </VButton>
+      <template v-if="props.status === 'AI_EXTRACTED'">
+        <VButton
+          variant="primary"
+          size="xs"
+          class="bg-emerald-600! hover:bg-emerald-700!"
+          @click="emit('accept')"
+        >
+          ACCEPT
+        </VButton>
 
-      <VButton
-        variant="ghost"
-        size="xs"
-        class="hover:bg-rose-50! hover:text-rose-600!"
-        @click="emit('reject')"
-      >
-        REJECT
-      </VButton>
+        <VButton
+          variant="ghost"
+          size="xs"
+          class="hover:bg-rose-50! hover:text-rose-600!"
+          @click="emit('reject')"
+        >
+          REJECT
+        </VButton>
+      </template>
+
+      <template v-else-if="props.status === 'USER_DRAFT'">
+        <VButton
+          variant="primary"
+          size="xs"
+          class="bg-indigo-600! hover:bg-indigo-700!"
+          @click="emit('accept')"
+        >
+          CONFIRM
+        </VButton>
+
+        <VButton
+          variant="ghost"
+          size="xs"
+          class="hover:bg-red-50! hover:text-red-600!"
+          @click="emit('delete')"
+        >
+          DELETE
+        </VButton>
+      </template>
     </VCluster>
   </VBox>
 </template>
 
 <script setup lang="ts">
-/**
- * VNodeActionGroup Molecule
- * Technical Responsibility: Orchestrating the decision interface for AI_EXTRACTED nodes.
- * Adherence: Follows Rule 1 (No Bare Divs) and Rule 4 (Zero Margin Bleed) of Layout Atoms.
- */
 import VBox from '@/components/atoms/layout/VBox.vue'
 import VCluster from '@/components/atoms/layout/VCluster.vue'
 import VButton from '@/components/atoms/buttons/VButton.vue'
 
+const props = defineProps<{
+  status: string
+}>()
+
 const emit = defineEmits<{
-  /** Transitions node status to LOCKED */
   (e: 'accept'): void
-  /** Removes the node from the exploration state */
   (e: 'reject'): void
+  (e: 'delete'): void
 }>()
 </script>
 
 <style scoped>
 .v-node-action-group {
-  /* High z-index to ensure visibility above VNodeShape vector borders
-     and adjacent edges in the Vue Flow viewport.
-  */
   z-index: 50;
-  /* Glassmorphism adjustment for white background token */
   backdrop-filter: blur(4px);
   background-color: rgba(255, 255, 255, 0.9);
 }

--- a/src/components/molecules/canvases/VNodeFloatingEditor.vue
+++ b/src/components/molecules/canvases/VNodeFloatingEditor.vue
@@ -45,13 +45,51 @@
           />
         </VFormField>
 
-        <VCluster justify="end" gap="sm" class="w-full pt-2">
-          <VButton variant="ghost" size="sm" @click="cancelNodeEdit">
+        <VCluster justify="end" gap="xs" class="w-full">
+          <VButton variant="ghost" size="xs" @click="cancelNodeEdit">
             Cancel
           </VButton>
-          <VButton variant="primary" size="sm" @click="confirmNodeEdit">
-            Apply Changes
-          </VButton>
+
+          <template v-if="isUnverified">
+            <VButton
+              variant="secondary"
+              size="xs"
+              :disabled="!isValid"
+              @click="handleStateSubmit('USER_DRAFT')"
+            >
+              Save Draft
+            </VButton>
+            <VButton
+              variant="primary"
+              size="xs"
+              class="bg-emerald-600! hover:bg-emerald-700!"
+              icon-name="LockClosed"
+              :disabled="!isValid"
+              @click="handleStateSubmit('LOCKED')"
+            >
+              Lock Node
+            </VButton>
+          </template>
+
+          <template v-else>
+            <VButton
+              variant="secondary"
+              size="xs"
+              icon-name="ArchiveBox"
+              @click="handleStateSubmit('ON_HOLD')"
+            >
+              Put On Hold
+            </VButton>
+            <VButton
+              variant="primary"
+              size="xs"
+              icon-name="DocumentCheck"
+              :disabled="!isValid"
+              @click="handleStateSubmit('LOCKED')"
+            >
+              Save
+            </VButton>
+          </template>
         </VCluster>
       </VStack>
     </VBox>
@@ -59,6 +97,7 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue';
 import { NodeToolbar } from '@vue-flow/node-toolbar';
 import { Position } from '@vue-flow/core';
 import { useNodeInterceptor } from '@/composables/useNodeInterceptor';
@@ -79,6 +118,23 @@ const {
   confirmNodeEdit,
   cancelNodeEdit
 } = useNodeInterceptor();
+
+const currentNode = computed(() => {
+  const nodeId = context.editingNodeId.value;
+  return context.conceptualNodes.get(nodeId);
+});
+
+const isValid = computed(() => !!context.localNodeData.value.label?.trim());
+const isUnverified = computed(() => {
+  const status = currentNode.value?.status;
+  return status === 'USER_DRAFT' || status === 'AI_EXTRACTED';
+});
+
+async function handleStateSubmit(targetStatus: string) {
+  if (!isValid.value) return;
+  context.localNodeData.value.status = targetStatus;
+  await confirmNodeEdit();
+}
 </script>
 
 <style scoped>

--- a/src/components/molecules/canvases/VNodeFloatingEditor.vue
+++ b/src/components/molecules/canvases/VNodeFloatingEditor.vue
@@ -10,7 +10,7 @@
       rounded="xl"
       border="all"
       padding="md"
-      class="w-72 shadow-xl animate-in fade-in zoom-in duration-200 nodrag nopan"
+      class="w-72 shadow-xl animate-in fade-in zoom-in duration-200 nodrag nopan v-node-floating-editor"
     >
       <VStack gap="md">
         <VCluster justify="between" align="center" class="w-full">
@@ -45,52 +45,21 @@
           />
         </VFormField>
 
-        <VCluster justify="end" gap="xs" class="w-full">
-          <VButton variant="ghost" size="xs" @click="cancelNodeEdit">
-            Cancel
-          </VButton>
-
-          <template v-if="isUnverified">
-            <VButton
-              variant="secondary"
-              size="xs"
-              :disabled="!isValid"
-              @click="handleStateSubmit('USER_DRAFT')"
-            >
-              Save Draft
-            </VButton>
-            <VButton
-              variant="primary"
-              size="xs"
-              class="bg-emerald-600! hover:bg-emerald-700!"
-              icon-name="LockClosed"
-              :disabled="!isValid"
-              @click="handleStateSubmit('LOCKED')"
-            >
-              Lock Node
-            </VButton>
-          </template>
-
-          <template v-else>
-            <VButton
-              variant="secondary"
-              size="xs"
-              icon-name="ArchiveBox"
-              @click="handleStateSubmit('ON_HOLD')"
-            >
-              Put On Hold
-            </VButton>
-            <VButton
-              variant="primary"
-              size="xs"
-              icon-name="DocumentCheck"
-              :disabled="!isValid"
-              @click="handleStateSubmit('LOCKED')"
-            >
-              Save
-            </VButton>
-          </template>
-        </VCluster>
+        <VEntityStatusActionGroup
+          entity-type="node"
+          :is-locked="isLocked"
+          :is-modified="isNodeModified"
+          :disabled="!isValid"
+          :labels="{
+            unlockedHold: 'Save Draft',
+            unlockedPrimary: 'Lock Node',
+            unlockedPrimaryClass: 'bg-emerald-600! hover:bg-emerald-700!',
+            lockedHold: 'Put On Hold',
+            lockedPrimary: 'Save'
+          }"
+          @cancel="cancelNodeEdit"
+          @submit="handleStateSubmit"
+        />
       </VStack>
     </VBox>
   </NodeToolbar>
@@ -102,7 +71,7 @@ import { NodeToolbar } from '@vue-flow/node-toolbar';
 import { Position } from '@vue-flow/core';
 import { useNodeInterceptor } from '@/composables/useNodeInterceptor';
 
-// Atoms Layer Imports
+// Atoms Layer Layout & UI Component Imports
 import VBox from '@/components/atoms/layout/VBox.vue';
 import VStack from '@/components/atoms/layout/VStack.vue';
 import VCluster from '@/components/atoms/layout/VCluster.vue';
@@ -113,24 +82,58 @@ import VInput from '@/components/atoms/forms/VInput.vue';
 import VTextarea from '@/components/atoms/forms/VTextarea.vue';
 import VFormField from '@/components/molecules/forms/VFormField.vue';
 
+// Shared State Machine Action Component
+import VEntityStatusActionGroup from '@/components/molecules/domain/VEntityStatusActionGroup.vue';
+
+/**
+ * VNodeFloatingEditor Molecule
+ * Rendered contextually on top of active VueFlow node graphs using specialized toolbars.
+ * Connects directly to useNodeInterceptor state machines.
+ */
 const {
   context,
   confirmNodeEdit,
   cancelNodeEdit
 } = useNodeInterceptor();
 
+// --- Computed Analytical State Layers ---
+
+/**
+ * Resolves the underlying original node object stored inside the state Map context.
+ */
 const currentNode = computed(() => {
   const nodeId = context.editingNodeId.value;
   return context.conceptualNodes.get(nodeId);
 });
 
+/**
+ * Evaluates whether the target concept node state is finalized.
+ */
+const isLocked = computed(() => currentNode.value?.status === 'LOCKED');
+
+/**
+ * Enforces field validations preventing form submission if mandatory criteria are unmet.
+ */
 const isValid = computed(() => !!context.localNodeData.value.label?.trim());
-const isUnverified = computed(() => {
-  const status = currentNode.value?.status;
-  return status === 'USER_DRAFT' || status === 'AI_EXTRACTED';
+
+/**
+ * Tracks dirty fields to determine button eligibility states under LOCKED conditions.
+ */
+const isNodeModified = computed(() => {
+  if (!currentNode.value) return false;
+  return (
+    context.localNodeData.value.label?.trim() !== currentNode.value.label ||
+    (context.localNodeData.value.userNotes || '') !== (currentNode.value.userNotes || '')
+  );
 });
 
-async function handleStateSubmit(targetStatus: string) {
+// --- Action Delegations ---
+
+/**
+ * Dispatches status updates down to the store layers after binding target states.
+ * @param targetStatus Destination status derived from state machine rules.
+ */
+async function handleStateSubmit(targetStatus: 'LOCKED' | 'ON_HOLD' | 'USER_DRAFT') {
   if (!isValid.value) return;
   context.localNodeData.value.status = targetStatus;
   await confirmNodeEdit();
@@ -138,11 +141,23 @@ async function handleStateSubmit(targetStatus: string) {
 </script>
 
 <style scoped>
+.v-node-floating-editor {
+  user-select: none;
+}
+
+/* Micro-interaction layer animations for seamless popup entry */
 .animate-in {
   animation: fadeIn 0.15s ease-out;
 }
+
 @keyframes fadeIn {
-  from { opacity: 0; transform: scale(0.95); }
-  to { opacity: 1; transform: scale(1); }
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 </style>

--- a/src/components/molecules/canvases/VNodeFloatingEditor.vue
+++ b/src/components/molecules/canvases/VNodeFloatingEditor.vue
@@ -1,0 +1,92 @@
+<template>
+  <NodeToolbar
+    :node-id="context.editingNodeId.value"
+    :is-visible="context.isNodeEditActive.value"
+    :position="Position.Top"
+    class="z-50"
+  >
+    <VBox
+      background="white"
+      rounded="xl"
+      border="all"
+      padding="md"
+      class="w-72 shadow-xl animate-in fade-in zoom-in duration-200 nodrag nopan"
+    >
+      <VStack gap="md">
+        <VCluster justify="between" align="center" class="w-full">
+          <VCluster gap="xs" align="center">
+            <VIcon name="DocumentText" class="text-indigo-600 size-4" />
+            <VTypography weight="bold" size="sm">Refine Research Node</VTypography>
+          </VCluster>
+          <VButton
+            variant="ghost"
+            size="xs"
+            icon-only
+            icon-name="XMark"
+            @click="cancelNodeEdit"
+          />
+        </VCluster>
+
+        <VStack border="bottom" class="h-0 w-full" />
+
+        <VFormField id="concept-label" label="Concept / Label" size="sm">
+          <VInput
+            v-model="context.localNodeData.value.label"
+            placeholder="e.g., Socio-economic Resilience"
+            size="sm"
+          />
+        </VFormField>
+
+        <VFormField id="strategic-reflection" label="Strategic Reflection" size="sm">
+          <VTextarea
+            v-model="context.localNodeData.value.userNotes"
+            :rows="3"
+            placeholder="Record why this concept is critical..."
+          />
+        </VFormField>
+
+        <VCluster justify="end" gap="sm" class="w-full pt-2">
+          <VButton variant="ghost" size="sm" @click="cancelNodeEdit">
+            Cancel
+          </VButton>
+          <VButton variant="primary" size="sm" @click="confirmNodeEdit">
+            Apply Changes
+          </VButton>
+        </VCluster>
+      </VStack>
+    </VBox>
+  </NodeToolbar>
+</template>
+
+<script setup lang="ts">
+import { NodeToolbar } from '@vue-flow/node-toolbar';
+import { Position } from '@vue-flow/core';
+import { useNodeInterceptor } from '@/composables/useNodeInterceptor';
+
+// Atoms Layer Imports
+import VBox from '@/components/atoms/layout/VBox.vue';
+import VStack from '@/components/atoms/layout/VStack.vue';
+import VCluster from '@/components/atoms/layout/VCluster.vue';
+import VTypography from '@/components/atoms/indicators/VTypography.vue';
+import VIcon from '@/components/atoms/indicators/VIcon.vue';
+import VButton from '@/components/atoms/buttons/VButton.vue';
+import VInput from '@/components/atoms/forms/VInput.vue';
+import VTextarea from '@/components/atoms/forms/VTextarea.vue';
+import VFormField from '@/components/molecules/forms/VFormField.vue';
+
+const {
+  context,
+  confirmNodeEdit,
+  cancelNodeEdit
+} = useNodeInterceptor();
+</script>
+
+<style scoped>
+.animate-in {
+  animation: fadeIn 0.15s ease-out;
+}
+@keyframes fadeIn {
+  from { opacity: 0; transform: scale(0.95); }
+  to { opacity: 1; transform: scale(1); }
+}
+</style>

--- a/src/components/molecules/domain/VEntityStatusActionGroup.vue
+++ b/src/components/molecules/domain/VEntityStatusActionGroup.vue
@@ -1,0 +1,79 @@
+<template>
+  <VCluster justify="end" gap="md" class="w-full">
+    <VButton variant="tertiary" size="sm" @click="emit('cancel')">
+      Cancel
+    </VButton>
+
+    <template v-if="!props.isLocked">
+      <VButton
+        variant="secondary"
+        size="sm"
+        icon-name="ArchiveBox"
+        :disabled="props.disabled"
+        @click="emit('submit', 'ON_HOLD')"
+      >
+        {{ props.labels.unlockedHold || 'Put On Hold' }}
+      </VButton>
+
+      <VButton
+        variant="primary"
+        size="sm"
+        :icon-name="props.labels.unlockedPrimaryIcon || 'LockClosed'"
+        :class="props.labels.unlockedPrimaryClass"
+        :disabled="props.disabled"
+        @click="emit('submit', 'LOCKED')"
+      >
+        {{ props.labels.unlockedPrimary || 'Lock' }}
+      </VButton>
+    </template>
+
+    <template v-else>
+      <VButton
+        variant="secondary"
+        size="sm"
+        icon-name="ArchiveBox"
+        @click="emit('submit', 'ON_HOLD')"
+      >
+        {{ props.labels.lockedHold || 'Unlock & Hold' }}
+      </VButton>
+
+      <VButton
+        variant="primary"
+        size="sm"
+        icon-name="DocumentCheck"
+        :disabled="props.disabled || !props.isModified"
+        @click="emit('submit', 'LOCKED')"
+      >
+        {{ props.labels.lockedPrimary || 'Save Changes' }}
+      </VButton>
+    </template>
+  </VCluster>
+</template>
+
+<script setup lang="ts">
+import VCluster from '@/components/atoms/layout/VCluster.vue';
+import VButton from '@/components/atoms/buttons/VButton.vue';
+
+interface ActionGroupLabels {
+  unlockedHold?: string;
+  unlockedPrimary?: string;
+  unlockedPrimaryIcon?: string;
+  unlockedPrimaryClass?: string;
+  lockedHold?: string;
+  lockedPrimary?: string;
+}
+
+const props = withDefaults(defineProps<{
+  isLocked: boolean;
+  isModified: boolean;
+  disabled: boolean;
+  labels?: ActionGroupLabels;
+}>(), {
+  labels: () => ({})
+});
+
+const emit = defineEmits<{
+  (e: 'cancel'): void;
+  (e: 'submit', targetStatus: 'LOCKED' | 'ON_HOLD' | 'USER_DRAFT'): void;
+}>();
+</script>

--- a/src/components/organisms/canvases/ConceptualMapCanvas.vue
+++ b/src/components/organisms/canvases/ConceptualMapCanvas.vue
@@ -12,7 +12,6 @@
       @node-drag-stop="handleNodeDragStop"
       @connect="handleConnect"
       @edge-double-click="handleEdgeDoubleClick"
-      @node-double-click="handleNodeDoubleClick"
       @drop="onDrop"
       @dragover="onDragOver"
       @dragleave="onDragLeave"
@@ -125,6 +124,7 @@ const vueFlowEdges = computed(() => canvasContext.conceptualEdges.value.map(e =>
   animated: e.type === 'TRIGGERS',
   data: {
     type: e.type,
+    status: e.status,
     evidence: e.evidence,
     weight: e.weight
   },
@@ -156,9 +156,5 @@ function handleEdgeDoubleClick({ event, edge }: EdgeMouseEvent) {
   if (rawEdgeData) {
     canvasContext.openInterceptor(null, midpoint, rawEdgeData);
   }
-}
-
-function handleNodeDoubleClick(event: any) {
-  startNodeEdit(event.node.id);
 }
 </script>

--- a/src/components/organisms/canvases/ConceptualMapCanvas.vue
+++ b/src/components/organisms/canvases/ConceptualMapCanvas.vue
@@ -11,7 +11,6 @@
       :min-zoom="0.2"
       @node-drag-stop="handleNodeDragStop"
       @connect="handleConnect"
-      @edge-double-click="handleEdgeDoubleClick"
       @drop="onDrop"
       @dragover="onDragOver"
       @dragleave="onDragLeave"
@@ -138,21 +137,5 @@ function handleNodeDragStop({ node }: NodeDragEvent) {
     position: { x: node.position.x, y: node.position.y }
   };
   canvasContext.updateConceptualMapNode(updatedNode, 'move');
-}
-
-function handleEdgeDoubleClick({ event, edge }: EdgeMouseEvent) {
-  event.stopPropagation();
-  event.preventDefault();
-
-  const midpoint = {
-    x: (edge.sourceX + edge.targetX) / 2,
-    y: (edge.sourceY + edge.targetY) / 2,
-  };
-
-  const rawEdgeData = canvasContext.conceptualEdges.value.find((e: ConceptualEdge) => e.id === edge.id);
-
-  if (rawEdgeData) {
-    canvasContext.openInterceptor(null, midpoint, rawEdgeData);
-  }
 }
 </script>

--- a/src/components/organisms/canvases/ConceptualMapCanvas.vue
+++ b/src/components/organisms/canvases/ConceptualMapCanvas.vue
@@ -16,48 +16,13 @@
       @drop="onDrop"
       @dragover="onDragOver"
       @dragleave="onDragLeave"
-      @edit="startEdit"
     >
       <Background :pattern-gap="20" pattern-color="#e2e8f0" />
       <Controls position="bottom-left" class="mb-4 ml-4" />
       <VEdgeFloatingEditor />
+      <VNodeFloatingEditor />
 
     </VueFlow>
-
-    <VModal
-      :is-open="isEditModalOpen"
-      title="Refine Research Node"
-      size="md"
-    >
-      <template #header-icon>
-        <VIcon name="DocumentText" class="text-indigo-600" />
-      </template>
-
-      <VStack gap="lg" class="py-4">
-        <VFormField id="concept-label" label="Concept / Label">
-          <VInput
-            v-model="localLabel"
-            placeholder="e.g., Socio-economic Resilience"
-            size="lg"
-          />
-        </VFormField>
-
-        <VFormField id="strategic-reflection" label="Strategic Reflection">
-          <VTextarea
-            v-model="localNotes"
-            :rows="5"
-            placeholder="Record why this concept is critical..."
-          />
-        </VFormField>
-      </VStack>
-
-      <template #footer>
-        <VButtonToolbar :is-proceed-ready="false">
-          <VButton variant="ghost" @click="isEditModalOpen = false">Cancel</VButton>
-          <VButton variant="primary" @click="saveEdit">Apply Changes</VButton>
-        </VButtonToolbar>
-      </template>
-    </VModal>
   </VBox>
 </template>
 
@@ -69,22 +34,16 @@ import { VueFlow, type EdgeMouseEvent, type NodeDragEvent } from '@vue-flow/core
 import { computed, markRaw, provide, ref, watch } from 'vue';
 
 // Atoms & Molecules
-import VButton from '@/components/atoms/buttons/VButton.vue';
-import VInput from '@/components/atoms/forms/VInput.vue';
-import VTextarea from '@/components/atoms/forms/VTextarea.vue';
-import VIcon from '@/components/atoms/indicators/VIcon.vue';
 import VBox from '@/components/atoms/layout/VBox.vue';
-import VStack from '@/components/atoms/layout/VStack.vue';
 import VEdgeFloatingEditor from '@/components/molecules/canvases/VEdgeFloatingEditor.vue';
-import VModal from '@/components/molecules/feedback/VModal.vue';
-import VButtonToolbar from '@/components/molecules/forms/VButtonToolbar.vue';
-import VFormField from '@/components/molecules/forms/VFormField.vue';
+import VNodeFloatingEditor from '@/components/molecules/canvases/VNodeFloatingEditor.vue';
 import VConceptualEdge from '@/components/organisms/canvases/VConceptualEdge.vue';
 import VConceptualNode from '@/components/organisms/canvases/VConceptualNode.vue';
 
 import { useCanvasDrop } from '@/composables/useCanvasDrop';
 import { useConceptualMapContext } from '@/composables/useConceptualMapContext';
 import { useEdgeInterceptor } from '@/composables/useEdgeInterceptor';
+import { useNodeInterceptor } from '@/composables/useNodeInterceptor';
 import { ConceptualMapContextKey } from '@/constants/injection-keys';
 import type { ConceptualEdge, ConceptualNode } from '@/interfaces/conceptual-map';
 
@@ -122,7 +81,8 @@ watch(
 );
 
 const { onDragOver, onDrop, onDragLeave } = useCanvasDrop(canvasContext);
-const { startInterception } = useEdgeInterceptor(canvasContext);
+const { startEdgeEdit } = useEdgeInterceptor(canvasContext);
+const { startNodeEdit } = useNodeInterceptor(canvasContext);
 
 const edgeTypes = {
   REF: markRaw(VConceptualEdge),
@@ -170,13 +130,8 @@ const vueFlowEdges = computed(() => canvasContext.conceptualEdges.value.map(e =>
   },
 })));
 
-const isEditModalOpen = ref(false);
-const editingNode = ref<ConceptualNode | null>(null);
-const localLabel = ref('');
-const localNotes = ref('');
-
 function handleConnect(connection: any) {
-  startInterception(connection, canvasContext.conceptualNodes);
+  startEdgeEdit(connection, canvasContext.conceptualNodes);
 }
 
 function handleNodeDragStop({ node }: NodeDragEvent) {
@@ -204,30 +159,6 @@ function handleEdgeDoubleClick({ event, edge }: EdgeMouseEvent) {
 }
 
 function handleNodeDoubleClick(event: any) {
-  startEdit(event.node.id);
-}
-
-function startEdit(nodeId: string) {
-  const node = canvasContext.conceptualNodes.get(nodeId);
-
-  if (node) {
-    editingNode.value = node;
-    localLabel.value = node.label;
-    localNotes.value = node.userNotes ?? '';
-    isEditModalOpen.value = true;
-  }
-}
-
-function saveEdit() {
-  if (editingNode.value) {
-    const updatedNode: ConceptualNode = {
-      ...editingNode.value,
-      label: localLabel.value,
-      userNotes: localNotes.value
-    };
-
-    canvasContext.updateConceptualMapNode(updatedNode, 'edit');
-    isEditModalOpen.value = false;
-  }
+  startNodeEdit(event.node.id);
 }
 </script>

--- a/src/components/organisms/canvases/ConceptualMapCanvas.vue
+++ b/src/components/organisms/canvases/ConceptualMapCanvas.vue
@@ -42,7 +42,6 @@ import VConceptualNode from '@/components/organisms/canvases/VConceptualNode.vue
 import { useCanvasDrop } from '@/composables/useCanvasDrop';
 import { useConceptualMapContext } from '@/composables/useConceptualMapContext';
 import { useEdgeInterceptor } from '@/composables/useEdgeInterceptor';
-import { useNodeInterceptor } from '@/composables/useNodeInterceptor';
 import { ConceptualMapContextKey } from '@/constants/injection-keys';
 import type { ConceptualEdge, ConceptualNode } from '@/interfaces/conceptual-map';
 
@@ -81,7 +80,6 @@ watch(
 
 const { onDragOver, onDrop, onDragLeave } = useCanvasDrop(canvasContext);
 const { startEdgeEdit } = useEdgeInterceptor(canvasContext);
-const { startNodeEdit } = useNodeInterceptor(canvasContext);
 
 const edgeTypes = {
   REF: markRaw(VConceptualEdge),

--- a/src/components/organisms/canvases/VConceptualEdge.vue
+++ b/src/components/organisms/canvases/VConceptualEdge.vue
@@ -2,9 +2,10 @@
   <BaseEdge
     :id="props.id"
     :path="edgePath"
-    :marker-end="props.markerEnd"
+    :marker-end="props.data?.status === 'AI_EXTRACTED' ? undefined : props.markerEnd"
     :style="edgeStyle"
     class="v-conceptual-edge"
+    :class="{ 'suggested-glow-animation': props.data?.status === 'AI_EXTRACTED' }"
   />
 
   <EdgeLabelRenderer>
@@ -17,6 +18,19 @@
       class="nodrag nopan"
     >
       <VCluster
+        v-if="props.data?.status === 'AI_EXTRACTED'"
+        gap="xs"
+        align="center"
+        class="v-edge-pill px-2.5 py-1 rounded-full border border-indigo-200 bg-indigo-50 text-indigo-700 shadow-sm cursor-pointer transition-all hover:scale-105 active:scale-95 hover:shadow-indigo-100 hover:shadow-md"
+      >
+        <VIcon name="Sparkles" size="xs" class="text-indigo-600 animate-pulse" />
+        <VTypography size="xs" weight="bold" class="tracking-wide">
+          Connect?
+        </VTypography>
+      </VCluster>
+
+      <VCluster
+        v-else
         gap="xs"
         align="center"
         class="v-edge-pill px-2 py-1 rounded-full border shadow-sm transition-all group hover:shadow-md"
@@ -64,20 +78,13 @@ import VTypography from '@/components/atoms/indicators/VTypography.vue'
 import VIcon from '@/components/atoms/indicators/VIcon.vue'
 import VCluster from '@/components/atoms/layout/VCluster.vue'
 
-/**
- * VConceptualEdge Organism
- * Implements a semantic relationship link between research nodes.
- * Supports EdgeType visualization and evidence grounding indicators.
- */
 interface Props extends EdgeProps<ConceptualEdge> {
-  // Explicitly add these properties to resolve the TypeScript error
   sourceHandle?: string
   targetHandle?: string
 }
 const props = defineProps<Props>()
 
 // --- Path Calculation ---
-
 const pathData = computed(() => {
   const sourcePos = props.sourceHandle ? HANDLE_MAP[props.sourcePosition] : Position.Right
   const targetPos = props.targetHandle ? HANDLE_MAP[props.targetPosition] : Position.Left
@@ -95,12 +102,9 @@ const pathData = computed(() => {
 const edgePath = computed(() => pathData.value[0])
 const labelX = computed(() => pathData.value[1])
 const labelY = computed(() => pathData.value[2])
+
 // --- Theme & Visual Logic ---
 
-/**
- * Determine Badge variant based on EdgeType.
- * VALIDATES -> emerald (support), CONSTRAINS -> red (limit), TRIGGERS -> amber (causal).
- */
 const badgeVariant = computed(() => {
   const type = props.data?.type
   switch (type) {
@@ -117,12 +121,37 @@ const themeClasses = computed(() => {
   return 'bg-white border-slate-200 text-slate-700'
 })
 
-const edgeStyle = computed(() => ({
-  ...props.style,
-  strokeWidth: props.selected ? 3 : 2,
-  stroke: props.selected ? '#818cf8' : '#94a3b8',
-  transition: 'stroke 0.2s, stroke-width 0.2s',
-}))
+const edgeStyle = computed(() => {
+  const baseStyle = { ...props.style }
+  const isSuggested = props.data?.status === 'AI_EXTRACTED'
+  const isTrigger = props.data?.type === 'TRIGGERS'
+
+  if (isSuggested) {
+    return {
+      ...baseStyle,
+      strokeWidth: 3,
+      stroke: '#818cf8', // Indigo 400
+      strokeOpacity: 0.6,
+      strokeDasharray: '6, 6',
+    }
+  }
+
+  if (isTrigger) {
+    return {
+      ...baseStyle,
+      strokeWidth: props.selected ? 3 : 2,
+      stroke: props.selected ? '#818cf8' : '#d97706', // Amber 600
+      strokeDasharray: '5, 5',
+    }
+  }
+
+  return {
+    ...baseStyle,
+    strokeWidth: props.selected ? 3 : 2,
+    stroke: props.selected ? '#818cf8' : '#94a3b8',
+    transition: 'stroke 0.2s, stroke-width 0.2s',
+  }
+})
 </script>
 
 <style scoped>
@@ -131,7 +160,20 @@ const edgeStyle = computed(() => ({
 }
 
 .v-edge-pill {
-  /* Ensure the label doesn't interfere with canvas panning unless interacted with */
   user-select: none;
+}
+
+.suggested-glow-animation {
+  animation: edgeFlow 25s linear infinite;
+  filter: drop-shadow(0 0 4px rgba(129, 140, 248, 0.6));
+}
+
+@keyframes edgeFlow {
+  from {
+    stroke-dashoffset: 500;
+  }
+  to {
+    stroke-dashoffset: 0;
+  }
 }
 </style>

--- a/src/components/organisms/canvases/VConceptualEdge.vue
+++ b/src/components/organisms/canvases/VConceptualEdge.vue
@@ -9,16 +9,15 @@
   />
 
   <EdgeLabelRenderer>
-    <div
-      :style="{
-        position: 'absolute',
-        transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
-        pointerEvents: 'all',
-      }"
-      class="nodrag nopan"
+    <VBox
+      tag="div"
+      :style="labelContainerStyle"
+      class="nodrag nopan flex flex-col items-center justify-center gap-1.5"
+      title="Double click to edit details"
+      @dblclick.stop="handleLabelDoubleClick"
     >
       <VCluster
-        v-if="props.data?.status === 'AI_EXTRACTED'"
+        v-if="props.data?.status === 'AI_EXTRACTED' && !shouldRenderActionGroup"
         gap="xs"
         align="center"
         class="v-edge-pill px-2.5 py-1 rounded-full border border-indigo-200 bg-indigo-50 text-indigo-700 shadow-sm cursor-pointer transition-all hover:scale-105 active:scale-95 hover:shadow-indigo-100 hover:shadow-md"
@@ -30,7 +29,7 @@
       </VCluster>
 
       <VCluster
-        v-else
+        v-else-if="!shouldRenderActionGroup"
         gap="xs"
         align="center"
         class="v-edge-pill px-2 py-1 rounded-full border shadow-sm transition-all group hover:shadow-md"
@@ -56,27 +55,41 @@
           class="text-slate-400 group-hover:text-indigo-500"
         />
       </VCluster>
-    </div>
+
+      <VEntityCanvasQuickActions
+        v-if="shouldRenderActionGroup"
+        :status="props.data?.status"
+        class="animate-in fade-in zoom-in duration-150 z-50 shadow-xl"
+        @action="handleQuickAction"
+      />
+    </VBox>
   </EdgeLabelRenderer>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, inject } from 'vue'
 import {
   BaseEdge,
   EdgeLabelRenderer,
   getBezierPath,
+  useVueFlow,
   type EdgeProps,
   Position,
 } from '@vue-flow/core'
-import type { ConceptualEdge } from '@/interfaces/conceptual-map';
-import { HANDLE_MAP } from '@/constants/canvases';
+import { ConceptualMapContextKey } from '@/constants/injection-keys'
+import type { ConceptualEdge } from '@/interfaces/conceptual-map'
+import type { EntityActionType } from '@/interfaces/core'
+import { HANDLE_MAP } from '@/constants/canvases'
 
-// Components
+// Atoms & Shared Components Imports
+import VBox from '@/components/atoms/layout/VBox.vue'
 import VBadge from '@/components/atoms/indicators/VBadge.vue'
 import VTypography from '@/components/atoms/indicators/VTypography.vue'
 import VIcon from '@/components/atoms/indicators/VIcon.vue'
 import VCluster from '@/components/atoms/layout/VCluster.vue'
+
+// 🟢 Quick Action Micro-Toolbar Import
+import VEntityCanvasQuickActions from '@/components/molecules/canvases/VEntityCanvasQuickActions.vue'
 
 interface Props extends EdgeProps<ConceptualEdge> {
   sourceHandle?: string
@@ -84,7 +97,16 @@ interface Props extends EdgeProps<ConceptualEdge> {
 }
 const props = defineProps<Props>()
 
-// --- Path Calculation ---
+const context = inject(ConceptualMapContextKey)
+const { viewport } = useVueFlow()
+
+if (!context) {
+  throw new Error(
+    '[Architectural Violation] VConceptualEdge must be rendered within the tree of a <ConceptualMapCanvas>.'
+  );
+}
+
+// --- Path & Label Center Coordinates Calculation ---
 const pathData = computed(() => {
   const sourcePos = props.sourceHandle ? HANDLE_MAP[props.sourcePosition] : Position.Right
   const targetPos = props.targetHandle ? HANDLE_MAP[props.targetPosition] : Position.Left
@@ -102,6 +124,88 @@ const pathData = computed(() => {
 const edgePath = computed(() => pathData.value[0])
 const labelX = computed(() => pathData.value[1])
 const labelY = computed(() => pathData.value[2])
+
+// --- 🟢 Dynamic Layout & Scale Compensation Logic ---
+
+/**
+ * Bounds checker determining whether shortcut action panels are eligible for display.
+ */
+const shouldRenderActionGroup = computed(() => {
+  const isEditorClosed = !context.isNodeEditActive.value
+
+  return isEditorClosed && props.selected
+})
+
+/**
+ * Combines spatial position vectors with inverse scaling to fully resolve zoom distortion.
+ */
+const labelContainerStyle = computed(() => {
+  const currentZoom = viewport.value.zoom || 1
+  const inverseScale = 1 / currentZoom
+
+  return {
+    position: 'absolute' as const,
+    // Base placement mapped precisely on edge midpoint
+    left: '0px',
+    top: '0px',
+    // Compound matrix: handles centering offset AND scale neutralization simultaneously
+    transform: `translate(-50%, -50%) translate(${labelX.value}px, ${labelY.value}px) scale(${inverseScale})`,
+    transformOrigin: 'center center',
+    pointerEvents: 'all' as const,
+  }
+})
+
+/**
+ * Intercepts double-click gestures on the label wrapper, bridging current coordinates
+ * and edge parameters directly to the useEdgeInterceptor store layer.
+ */
+const handleLabelDoubleClick = () => {
+  if (!props.data) return
+
+  const position = {
+    x: labelX.value,
+    y: labelY.value
+  }
+
+  const edge = context.conceptualEdges.value.find((e: any) => e.id === props.id)
+  context.openInterceptor(null, position, edge);
+}
+
+// --- 🟢 Reengineered Edge Quick Mutation Handlers ---
+
+const handleQuickAction = async (action: EntityActionType) => {
+  const edge = context.conceptualEdges.value.find((e: any) => e.id === props.id)
+  if (!edge) return
+
+  switch (action) {
+    case 'ACCEPT':
+    case 'LOCK':
+      edge.status = 'LOCKED'
+      await context.updateConceptualMapEdge(edge, 'update')
+      break
+
+    case 'REJECT':
+      // Drop AI extracted proposals directly from the active viewport map
+      await context.updateConceptualMapEdge(edge, 'delete')
+      break
+
+    case 'HOLD':
+      edge.status = 'ON_HOLD'
+      await context.updateConceptualMapEdge(edge, 'update')
+      break
+
+    case 'DRAFT':
+      edge.status = 'USER_DRAFT'
+      await context.updateConceptualMapEdge(edge, 'update')
+      break
+
+    case 'DELETE':
+      if (confirm('Delete this relationship permanently?')) {
+        await context.updateConceptualMapEdge(edge, 'delete')
+      }
+      break
+  }
+}
 
 // --- Theme & Visual Logic ---
 
@@ -168,6 +272,10 @@ const edgeStyle = computed(() => {
   filter: drop-shadow(0 0 4px rgba(129, 140, 248, 0.6));
 }
 
+.animate-in {
+  animation: fadeIn 0.15s ease-out;
+}
+
 @keyframes edgeFlow {
   from {
     stroke-dashoffset: 500;
@@ -175,5 +283,10 @@ const edgeStyle = computed(() => {
   to {
     stroke-dashoffset: 0;
   }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: scale(0.92); }
+  to { opacity: 1; transform: scale(1); }
 }
 </style>

--- a/src/components/organisms/canvases/VConceptualNode.vue
+++ b/src/components/organisms/canvases/VConceptualNode.vue
@@ -19,7 +19,7 @@
             icon-only
             icon-name="PencilSquare"
             class="opacity-0 group-hover:opacity-100 transition-opacity"
-            @click.stop="emit('edit', props.data.id)"
+            @click.stop="context.openNodeEditor(props.id, props.data)"
           />
         </VCluster>
 
@@ -71,7 +71,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, inject } from 'vue'
 import { Position, type NodeProps } from '@vue-flow/core'
 import type { ConceptualNode } from '@/interfaces/conceptual-map'
 import { NODE_THEMES } from '@/constants/canvases'
@@ -84,6 +84,16 @@ import VTypography from '@/components/atoms/indicators/VTypography.vue'
 import VCluster from '@/components/atoms/layout/VCluster.vue'
 import VStack from '@/components/atoms/layout/VStack.vue'
 import VNodeContainer from '@/components/organisms/canvases/VNodeContainer.vue'
+import { ConceptualMapContextKey } from '@/constants/injection-keys';
+
+const context = inject(ConceptualMapContextKey);
+
+if (!context) {
+  throw new Error(
+    '[Architectural Violation] VConceptualNode must be rendered within the tree of a <ConceptualMapCanvas>.'
+  );
+}
+
 
 /**
  * VConceptualNode Organism
@@ -92,10 +102,6 @@ import VNodeContainer from '@/components/organisms/canvases/VNodeContainer.vue'
  */
 interface Props extends NodeProps<ConceptualNode> {}
 const props = defineProps<Props>()
-
-const emit = defineEmits<{
-  (e: 'edit', id: string): void
-}>()
 
 // Computed theme based on the NodeType defined in constants/canvases.ts
 const theme = computed(() => {

--- a/src/components/organisms/canvases/VNodeContainer.vue
+++ b/src/components/organisms/canvases/VNodeContainer.vue
@@ -8,12 +8,11 @@
 
     <VNodeShape :status="props.status" :border-radius="12" />
 
-    <VNodeActionGroup
+    <VEntityCanvasQuickActions
       v-if="shouldRenderActionGroup"
       :status="props.status"
-      @accept="handleAccept"
-      @reject="handleReject"
-      @delete="handleDelete"
+      class="absolute -top-12 left-1/2 -translate-x-1/2 z-50 animate-in fade-in zoom-in duration-150 nodrag nopan"
+      @action="handleQuickAction"
     />
 
     <slot name="overlay" />
@@ -26,12 +25,16 @@
  * The physical shell for all canvas nodes.
  * Implements semantic border logic (Solid/Dashed) and hover/selection states.
  */
-import { inject } from 'vue';
+import { inject, computed } from 'vue';
+import { ConceptualMapContextKey } from '@/constants/injection-keys';
+import type { EntityActionType } from '@/interfaces/core';
+
+// Atoms & Shared Core Imports
 import VNodeShape from '@/components/atoms/canvases/VNodeShape.vue';
 import VNodeShield from '@/components/atoms/canvases/VNodeShield.vue';
-import VNodeActionGroup from '@/components/molecules/canvases/VNodeActionGroup.vue';
-import { computed, ref, watch } from 'vue';
-import { ConceptualMapContextKey } from '@/constants/injection-keys';
+
+// 🟢 Import the new unified micro-toolbar actions component and type definition
+import VEntityCanvasQuickActions from '@/components/molecules/canvases/VEntityCanvasQuickActions.vue';
 
 const context = inject(ConceptualMapContextKey);
 
@@ -43,7 +46,7 @@ if (!context) {
 
 const props = withDefaults(defineProps<{
   id: string
-  // Entity status from backend (e.g., 'AI_EXTRACTED', 'LOCKED')
+  // Entity status from backend (e.g., 'AI_EXTRACTED', 'LOCKED', 'USER_DRAFT')
   status?: string
   // Selection state provided by Vue Flow
   selected?: boolean
@@ -58,47 +61,72 @@ const props = withDefaults(defineProps<{
   padding: 'md'
 })
 
+// --- Computed Analytical State Layers ---
+
 const shouldRenderActionGroup = computed(() => {
-  const isValidStatus = ['AI_EXTRACTED', 'USER_DRAFT'].includes(props.status);
+  // Enhanced boundary: Allows quick-action toolbars to manage AI Extractions, Drafts, and Hold states.
   const isEditorClosed = !context.isNodeEditActive.value;
 
-  return isValidStatus && isEditorClosed && props.selected;
+  return isEditorClosed && props.selected;
 });
+
 const nodeData = computed(() => context.conceptualNodes.get(props.id));
 
+// --- 🟢 Reengineered Action Routing Stream ---
+
 /**
- * Technical Logic: Operation Handlers
- * These functions bubble events up to the Page/Canvas level where
- * the Exploration Store (exploration.ts) resides.
+ * Technical Responsibility: Orchestrates incoming single-click event requests
+ * dispatched from the micro-toolbar layer and normalizes graph mutation streams.
+ * * @param action Explicit action identifier derived from CanvasActionType
  */
-const handleAccept = async () => {
-  let node = nodeData.value;
-  if (node !== undefined) {
-    node.status = 'LOCKED';
-    await context.updateConceptualMapNode(node, 'edit');
+const handleQuickAction = async (action: EntityActionType) => {
+  const node = nodeData.value;
+  if (!node) return;
 
-    if (props.status === 'AI_EXTRACTED') {
-      context.recommendConceptualNodes();
-    }
-  }
-}
+  switch (action) {
+    case 'ACCEPT':
+    case 'LOCK':
+      node.status = 'LOCKED';
+      await context.updateConceptualMapNode(node, 'edit');
 
-const handleReject = () => {
-  let node = nodeData.value;
-  if (node !== undefined) {
-    context.updateConceptualMapNode(node, 'delete');
-  }
-}
+      // Proactively prompt additional map concepts if accepting raw AI discoveries
+      if (props.status === 'AI_EXTRACTED') {
+        context.recommendConceptualNodes();
+      }
+      break;
 
-const handleDelete = () => {
-  let node = nodeData.value;
-  if (node !== undefined) {
-    if (confirm('Delete this draft node?')) {
-      context.updateConceptualMapNode(node, 'delete');
-    }
+    case 'REJECT':
+      // Map 'REJECT' directly to complete graph node extraction rollback
+      await context.updateConceptualMapNode(node, 'delete');
+      break;
+
+    case 'HOLD':
+      node.status = 'ON_HOLD';
+      await context.updateConceptualMapNode(node, 'edit');
+      break;
+
+    case 'DRAFT':
+      node.status = 'USER_DRAFT';
+      await context.updateConceptualMapNode(node, 'edit');
+      break;
+
+    case 'DELETE':
+      if (confirm('Delete this draft node permanently?')) {
+        await context.updateConceptualMapNode(node, 'delete');
+      }
+      break;
   }
-}
+};
 </script>
 
 <style scoped>
+/* Ensure smooth micro-interaction layouts on selection change */
+.animate-in {
+  animation: fadeIn 0.15s ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translate(-50%, -35%) scale(0.95); }
+  to { opacity: 1; transform: translate(-50%, -40%) scale(1); }
+}
 </style>

--- a/src/components/organisms/canvases/VNodeContainer.vue
+++ b/src/components/organisms/canvases/VNodeContainer.vue
@@ -9,9 +9,11 @@
     <VNodeShape :status="props.status" :border-radius="12" />
 
     <VNodeActionGroup
-      v-if="props.status === 'AI_EXTRACTED' && props.selected"
+      v-if="shouldRenderActionGroup"
+      :status="props.status"
       @accept="handleAccept"
       @reject="handleReject"
+      @delete="handleDelete"
     />
 
     <slot name="overlay" />
@@ -28,7 +30,7 @@ import { inject } from 'vue';
 import VNodeShape from '@/components/atoms/canvases/VNodeShape.vue';
 import VNodeShield from '@/components/atoms/canvases/VNodeShield.vue';
 import VNodeActionGroup from '@/components/molecules/canvases/VNodeActionGroup.vue';
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { ConceptualMapContextKey } from '@/constants/injection-keys';
 
 const context = inject(ConceptualMapContextKey);
@@ -56,6 +58,12 @@ const props = withDefaults(defineProps<{
   padding: 'md'
 })
 
+const shouldRenderActionGroup = computed(() => {
+  const isValidStatus = ['AI_EXTRACTED', 'USER_DRAFT'].includes(props.status);
+  const isEditorClosed = !context.isNodeEditActive.value;
+
+  return isValidStatus && isEditorClosed && props.selected;
+});
 const nodeData = computed(() => context.conceptualNodes.get(props.id));
 
 /**
@@ -68,7 +76,10 @@ const handleAccept = async () => {
   if (node !== undefined) {
     node.status = 'LOCKED';
     await context.updateConceptualMapNode(node, 'edit');
-    context.recommendConceptualNodes();
+
+    if (props.status === 'AI_EXTRACTED') {
+      context.recommendConceptualNodes();
+    }
   }
 }
 
@@ -76,6 +87,15 @@ const handleReject = () => {
   let node = nodeData.value;
   if (node !== undefined) {
     context.updateConceptualMapNode(node, 'delete');
+  }
+}
+
+const handleDelete = () => {
+  let node = nodeData.value;
+  if (node !== undefined) {
+    if (confirm('Delete this draft node?')) {
+      context.updateConceptualMapNode(node, 'delete');
+    }
   }
 }
 </script>

--- a/src/components/organisms/forms/KeywordDetailEditor.vue
+++ b/src/components/organisms/forms/KeywordDetailEditor.vue
@@ -1,6 +1,5 @@
 <template>
   <VBox tag="section" background="white" class="flex flex-col h-full overflow-hidden">
-
     <VBox padding="lg" border="bottom" class="shrink-0">
       <VCluster gap="md" align="center">
         <VBox padding="sm" background="indigo-50" rounded="xl" class="text-indigo-600 shadow-sm">
@@ -19,7 +18,6 @@
 
     <VBox tag="main" padding="lg" class="flex-1 overflow-y-auto stable-gutter">
       <VStack gap="xl">
-
         <VFormField id="keyword-input" label="Keyword Text">
           <template #hint>
             <VBadge v-if="isTextModified" variant="amber" size="xs" class="animate-pulse">
@@ -47,7 +45,7 @@
         </VFormField>
 
         <VStack gap="sm">
-          <VEntityProjectStatus :status="initialKeyword.entityStatus">
+          <VEntityProjectStatus :status="props.initialKeyword.entityStatus">
             <template v-if="isTextModified" #default>
               <VTypography size="xs" color="amber-600" italic class="mt-1">
                 Note: Saving will update content and persist the choice below.
@@ -55,70 +53,31 @@
             </template>
           </VEntityProjectStatus>
         </VStack>
-
       </VStack>
     </VBox>
 
     <VBox padding="md" background="slate-50" border="top" class="shrink-0">
-      <VCluster justify="end" gap="md">
-        <VButton variant="tertiary" @click="handleCancel">
-          Cancel
-        </VButton>
-
-        <template v-if="!isLocked">
-          <VButton
-            variant="secondary"
-            icon-name="ArchiveBox"
-            :disabled="!isValid"
-            @click="handleSubmit('ON_HOLD')"
-          >
-            Put On Hold
-          </VButton>
-
-          <VButton
-            variant="primary"
-            icon-name="LockClosed"
-            :disabled="!isValid"
-            @click="handleSubmit('LOCKED')"
-          >
-            Lock Keyword
-          </VButton>
-        </template>
-
-        <template v-else>
-          <VButton
-            variant="secondary"
-            icon-name="ArchiveBox"
-            @click="handleSubmit('ON_HOLD')"
-          >
-            Unlock & Hold
-          </VButton>
-
-          <VButton
-            variant="primary"
-            icon-name="DocumentCheck"
-            :disabled="!isTextModified"
-            @click="handleSubmit('LOCKED')"
-          >
-            Save Changes
-          </VButton>
-        </template>
-      </VCluster>
+      <VEntityStatusActionGroup
+        :is-locked="isLocked"
+        :is-modified="isTextModified"
+        :disabled="!isValid"
+        :labels="{
+          unlockedPrimary: 'Lock Keyword'
+        }"
+        @cancel="handleCancel"
+        @submit="handleSubmit"
+      />
     </VBox>
   </VBox>
 </template>
 
 <script setup lang="ts">
-/**
- * KeywordDetailEditor
- * Integrated refactor using specialized status molecules.
- */
 import { computed, ref, watch } from 'vue';
 import type { EntityStatus } from '@/interfaces/core';
 import type { ProcessedKeyword } from '@/interfaces/initiation';
 import { useInitiativeStore } from '@/stores/initiation';
 
-// Atoms
+// Atoms Layer Layout & UI Component Imports
 import VBox from '@/components/atoms/layout/VBox.vue';
 import VStack from '@/components/atoms/layout/VStack.vue';
 import VCluster from '@/components/atoms/layout/VCluster.vue';
@@ -128,11 +87,18 @@ import VTypography from '@/components/atoms/indicators/VTypography.vue';
 import VTextarea from '@/components/atoms/forms/VTextarea.vue';
 import VBadge from '@/components/atoms/indicators/VBadge.vue';
 
-// Molecules
+// Molecules Layer Component Imports
 import VFormField from '@/components/molecules/forms/VFormField.vue';
 import VEntityProjectStatus from '@/components/molecules/domain/VEntityProjectStatus.vue';
-import VFeasibilityStatus from '@/components/molecules/domain/VFeasibilityStatus.vue';
 
+// Shared State Machine Action Component
+import VEntityStatusActionGroup from '@/components/molecules/domain/VEntityStatusActionGroup.vue';
+
+/**
+ * KeywordDetailEditor Molecule
+ * Provides a dedicated detail panel to refine specific keywords used for domain exploration.
+ * Seamlessly abstracts lifecycle submission variants via unified action groups.
+ */
 const props = defineProps<{
   keywordIndex: number;
   initialKeyword: ProcessedKeyword;
@@ -145,16 +111,35 @@ const emit = defineEmits<{
 const initiativeStore = useInitiativeStore();
 const draftText = ref(props.initialKeyword.label);
 
-// Sync draft with external props
-watch(() => props.initialKeyword.label, (val) => (draftText.value = val));
+/**
+ * Reactively syncs local state whenever the parent scope updates the target keyword attributes.
+ */
+watch(() => props.initialKeyword.label, (val) => {
+  draftText.value = val;
+});
 
-// Computed Logic
-const isValid = computed(() => !!draftText.value.trim());
-const isLocked = computed(() => props.initialKeyword.entityStatus === 'LOCKED');
-const isTextModified = computed(() => draftText.value.trim() !== props.initialKeyword.label);
+// --- Computed Analytical State Layers ---
 
 /**
- * Persist changes to store
+ * Validates whether the keyword form constraints are legally satisfied.
+ */
+const isValid = computed(() => !!draftText.value.trim());
+
+/**
+ * Resolves whether the specific keyword state machine is already finalized or hardened.
+ */
+const isLocked = computed(() => props.initialKeyword.entityStatus === 'LOCKED');
+
+/**
+ * Determines whether user modifications are pending synchronization with the cloud backend streams.
+ */
+const isTextModified = computed(() => draftText.value.trim() !== props.initialKeyword.label);
+
+// --- Action Delegations ---
+
+/**
+ * Dispatches synchronization requests upstream to persistence layers and closes the active modal view.
+ * @param targetStatus Destination lifecycle status assigned via action choices.
  */
 async function handleSubmit(targetStatus: EntityStatus) {
   if (!isValid.value) return;
@@ -167,10 +152,12 @@ async function handleSubmit(targetStatus: EntityStatus) {
 }
 
 /**
- * Safety check for dirty state
+ * Safety interceptor protecting unsaved user data states prior to exiting edit view contexts.
  */
 function handleCancel() {
-  if (isTextModified.value && !window.confirm('Discard unsaved changes?')) return;
+  if (isTextModified.value && !window.confirm('Discard unsaved changes?')) {
+    return;
+  }
   emit('close-modal');
 }
 </script>

--- a/src/components/organisms/forms/ScopeDetailEditor.vue
+++ b/src/components/organisms/forms/ScopeDetailEditor.vue
@@ -1,6 +1,5 @@
 <template>
   <VBox tag="section" background="white" class="flex flex-col h-full overflow-hidden">
-
     <VBox padding="lg" border="bottom" class="shrink-0">
       <VCluster justify="between" align="center">
         <VCluster gap="md" align="center">
@@ -15,10 +14,10 @@
           </VBox>
           <VStack gap="none">
             <VTypography tag="h2" size="xl" weight="bold" color="slate-900">
-              Refine Scope: {{ initialScopeElement.label }}
+              Refine Scope: {{ props.initialScopeElement.label }}
             </VTypography>
             <VBadge :variant="boundaryConfig.badgeColor" size="xs">
-              {{ initialScopeElement.boundaryType }} CRITERIA
+              {{ props.initialScopeElement.boundaryType }} CRITERIA
             </VBadge>
           </VStack>
         </VCluster>
@@ -27,7 +26,6 @@
 
     <VBox tag="main" padding="lg" class="flex-1 overflow-y-auto stable-gutter">
       <VStack gap="xl">
-
         <VFormField id="scope-value-input" label="Boundary Specification">
           <template #hint>
             <VBadge v-if="isValueModified" variant="amber" size="xs" class="animate-pulse">
@@ -41,10 +39,11 @@
                 :id="id"
                 v-model="draftValue"
                 :rows="3"
-                :placeholder="`Describe parameters for ${initialScopeElement.label}...`"
+                :placeholder="`Describe parameters for ${props.initialScopeElement.label}...`"
                 class="w-full text-md font-medium leading-relaxed p-4"
                 :class="{ 'border-red-500 ring-red-100': !isValid }"
               />
+
               <VCluster v-if="!isValid" gap="xs" align="center" class="text-red-500">
                 <VIcon name="ExclamationCircle" size="xs" />
                 <VTypography size="xs">Specification cannot be empty.</VTypography>
@@ -54,94 +53,62 @@
         </VFormField>
 
         <VStack gap="sm">
-          <VEntityProjectStatus :status="initialScopeElement.entityStatus" />
+          <VEntityProjectStatus :status="props.initialScopeElement.entityStatus" />
 
           <VFeasibilityStatus
-            :status="feasibilityStatus"
-            :title="`Strategic Impact: ${initialScopeElement.label}`"
+            :status="props.feasibilityStatus"
+            :title="`Strategic Impact: ${props.initialScopeElement.label}`"
           >
             Precisely defining this scope will directly influence the volume and quality of resources the system retrieves.
           </VFeasibilityStatus>
         </VStack>
-
       </VStack>
     </VBox>
 
     <VBox padding="md" background="slate-50" border="top" class="shrink-0">
-      <VCluster justify="end" gap="md">
-        <VButton variant="tertiary" @click="handleCancel">
-          Cancel
-        </VButton>
-
-        <template v-if="!isLocked">
-          <VButton
-            variant="secondary"
-            icon-name="ArchiveBox"
-            :disabled="!isValid"
-            @click="handleSubmit('ON_HOLD')"
-          >
-            Put On Hold
-          </VButton>
-
-          <VButton
-            variant="primary"
-            icon-name="LockClosed"
-            :disabled="!isValid"
-            @click="handleSubmit('LOCKED')"
-          >
-            Lock Scope
-          </VButton>
-        </template>
-
-        <template v-else>
-          <VButton
-            variant="secondary"
-            icon-name="ArchiveBox"
-            @click="handleSubmit('ON_HOLD')"
-          >
-            Unlock & Hold
-          </VButton>
-
-          <VButton
-            variant="primary"
-            icon-name="DocumentCheck"
-            :disabled="!isValueModified"
-            @click="handleSubmit('LOCKED')"
-          >
-            Save Changes
-          </VButton>
-        </template>
-      </VCluster>
+      <VEntityStatusActionGroup
+        :is-locked="isLocked"
+        :is-modified="isValueModified"
+        :disabled="!isValid"
+        :labels="{
+          unlockedPrimary: 'Lock Scope'
+        }"
+        @cancel="handleCancel"
+        @submit="handleSubmit"
+      />
     </VBox>
   </VBox>
 </template>
 
 <script setup lang="ts">
-/**
- * ScopeDetailEditor
- * Refactored to use standardized Indicator molecules and color-based VBadge.
- */
 import { computed, ref, watch } from 'vue';
 import { apiService } from '@/api/apiService';
 import { useInitiativeStore } from '@/stores/initiation';
 import type { EntityStatus, FeasibilityStatus } from '@/interfaces/core';
 import type { ProcessedScope } from '@/interfaces/initiation';
 
-// Atoms
+// Atoms Layer Layout & UI Component Imports
 import VBox from '@/components/atoms/layout/VBox.vue';
 import VStack from '@/components/atoms/layout/VStack.vue';
 import VCluster from '@/components/atoms/layout/VCluster.vue';
-import VButton from '@/components/atoms/buttons/VButton.vue';
 import VIcon from '@/components/atoms/indicators/VIcon.vue';
 import VTypography from '@/components/atoms/indicators/VTypography.vue';
 import VTextarea from '@/components/atoms/forms/VTextarea.vue';
 import VBadge from '@/components/atoms/indicators/VBadge.vue';
 
-// Molecules
+// Molecules Layer Component Imports
 import VFormField from '@/components/molecules/forms/VFormField.vue';
 import VEntityProjectStatus from '@/components/molecules/domain/VEntityProjectStatus.vue';
 import VFeasibilityStatus from '@/components/molecules/domain/VFeasibilityStatus.vue';
 
+// Shared State Machine Action Component
+import VEntityStatusActionGroup from '@/components/molecules/domain/VEntityStatusActionGroup.vue';
+
+/**
+ * ScopeDetailEditor Molecule
+ * Provides a granular specification configuration sheet to align macro project inclusion/exclusion bounds.
+ * Implements centralized action dispatch patterns to minimize state drift debt.
+ */
 const props = defineProps<{
   scopeIndex: number;
   initialScopeElement: ProcessedScope;
@@ -155,45 +122,75 @@ const emit = defineEmits<{
 const initiativeStore = useInitiativeStore();
 const draftValue = ref(props.initialScopeElement.rationale);
 
-watch(() => props.initialScopeElement.rationale, (val) => (draftValue.value = val));
+/**
+ * Reactively syncs local state whenever the parent architecture triggers an updated rationale data flow.
+ */
+watch(() => props.initialScopeElement.rationale, (val) => {
+  draftValue.value = val;
+});
 
-// Logic Helpers
+// --- Computed Analytical State Layers ---
+
+/**
+ * Ensures validation constraints are met before committing down to transaction branches.
+ */
 const isValid = computed(() => !!draftValue.value?.trim());
+
+/**
+ * Resolves whether the targeted project scope segment is marked as confirmed and frozen.
+ */
 const isLocked = computed(() => props.initialScopeElement.entityStatus === 'LOCKED');
+
+/**
+ * Validates dirty state status to enable/disable specific locked submit combinations.
+ */
 const isValueModified = computed(() => draftValue.value?.trim() !== props.initialScopeElement.rationale);
 
 /**
  * Boundary UI Configuration
- * Maps INCLUSION/EXCLUSION to visual tokens.
+ * Dynamically resolves structural classes and tokens depending on INCLUSION / EXCLUSION configurations.
  */
 const boundaryConfig = computed(() => {
   const isInclusion = props.initialScopeElement.boundaryType === 'INCLUSION';
   return {
-    icon: isInclusion ? 'PlusCircle' : 'MinusCircle' as const,
+    icon: (isInclusion ? 'PlusCircle' : 'MinusCircle') as any,
     bg: (isInclusion ? 'emerald-50' : 'rose-50') as any,
     text: isInclusion ? 'text-emerald-600' : 'text-rose-600',
     badgeColor: (isInclusion ? 'emerald' : 'red') as any
   };
 });
 
+// --- Action Delegations ---
+
+/**
+ * Persists updated boundaries downstream via parallel API mutations and store dispatches.
+ * @param targetStatus Destination state assigned through footer selection interactions.
+ */
 async function handleSubmit(targetStatus: EntityStatus) {
   const value = draftValue.value?.trim();
   if (!value) return;
 
   const { id, label } = props.initialScopeElement;
 
+  // Persist directly via service wrappers depending on record origin profiles
   if (id) {
     await apiService.knowledge.scopes.update(id, label, value, targetStatus);
   } else {
     await apiService.projects.scopes.create(label, value, targetStatus);
   }
 
+  // Update unified in-memory application store states
   initiativeStore.createOrUpdateTopicScopes(id, label, value, targetStatus);
   emit('close-modal');
 }
 
+/**
+ * Intercepts cancel paths when dirty attributes risk tracking breaks or missing edits.
+ */
 function handleCancel() {
-  if (isValueModified.value && !window.confirm('Discard unsaved scope changes?')) return;
+  if (isValueModified.value && !window.confirm('Discard unsaved scope changes?')) {
+    return;
+  }
   emit('close-modal');
 }
 </script>

--- a/src/composables/useConceptualMapContext.ts
+++ b/src/composables/useConceptualMapContext.ts
@@ -64,7 +64,8 @@ export function useConceptualMapContext(config?: ContextConfig) {
   const editingNodeId = ref<string>('');
   const localNodeData = ref({
     label: '',
-    userNotes: ''
+    userNotes: '',
+    status: ''
   });
 
   const openNodeEditor = (nodeId: string, node: ConceptualNode) => {
@@ -72,14 +73,15 @@ export function useConceptualMapContext(config?: ContextConfig) {
     editingNodeId.value = nodeId;
     localNodeData.value = {
       label: node.label || '',
-      userNotes: node.userNotes || ''
+      userNotes: node.userNotes || '',
+      status: node.status || 'LOCKED'
     };
   };
 
   const closeNodeEditor = () => {
     isNodeEditActive.value = false;
     editingNodeId.value = '';
-    localNodeData.value = { label: '', userNotes: '' };
+    localNodeData.value = { label: '', userNotes: '', status: '' };
   };
 
   // --------------------------------------------------------------------------

--- a/src/composables/useConceptualMapContext.ts
+++ b/src/composables/useConceptualMapContext.ts
@@ -170,7 +170,24 @@ export function useConceptualMapContext(config?: ContextConfig) {
    * Dispatches node updates including moving, editing, or structural deletes.
    */
   const updateConceptualMapNode = async (node: ConceptualNode, action: 'move' | 'link' | 'edit' | 'delete' | 'group') => {
-    if (action === 'delete') {
+    const canvasId = config?.getCanvasId ? config.getCanvasId() : null;
+    if (!canvasId) {
+      console.log('[Context API Warning] Missing canvas ID in configuration. Edge update aborted.');
+      return;
+    }
+
+    if (action === 'edit') {
+      let modifiedNodeData = {
+        ...node,
+        position: {
+          x: node.position!.x / POSITION_SCALE,
+          y: node.position!.y / POSITION_SCALE
+        }
+      };
+      await apiService.canvases.nodes.update(canvasId, node.id, modifiedNodeData);
+      conceptualNodes.set(node.id, node);
+    } else if (action === 'delete') {
+      await apiService.canvases.nodes.delete(canvasId, node.id);
       conceptualNodes.delete(node.id);
       // Cascade delete associated edges to prevent dangling connections
       conceptualEdges.value = conceptualEdges.value.filter(e => e.source !== node.id && e.target !== node.id);

--- a/src/composables/useConceptualMapContext.ts
+++ b/src/composables/useConceptualMapContext.ts
@@ -58,6 +58,31 @@ export function useConceptualMapContext(config?: ContextConfig) {
   });
 
   // --------------------------------------------------------------------------
+  // Low-Frequency Node Editor Form States
+  // --------------------------------------------------------------------------
+  const isNodeEditActive = ref(false);
+  const editingNodeId = ref<string>('');
+  const localNodeData = ref({
+    label: '',
+    userNotes: ''
+  });
+
+  const openNodeEditor = (nodeId: string, node: ConceptualNode) => {
+    isNodeEditActive.value = true;
+    editingNodeId.value = nodeId;
+    localNodeData.value = {
+      label: node.label || '',
+      userNotes: node.userNotes || ''
+    };
+  };
+
+  const closeNodeEditor = () => {
+    isNodeEditActive.value = false;
+    editingNodeId.value = '';
+    localNodeData.value = { label: '', userNotes: '' };
+  };
+
+  // --------------------------------------------------------------------------
   // B. Cache Orchestration Pipeline
   // --------------------------------------------------------------------------
 
@@ -269,6 +294,9 @@ export function useConceptualMapContext(config?: ContextConfig) {
     interceptorPosition,
     pendingConnection,
     localEdgeData,
+    isNodeEditActive,
+    editingNodeId,
+    localNodeData,
 
     // Actions
     fetchGraphData,
@@ -278,6 +306,8 @@ export function useConceptualMapContext(config?: ContextConfig) {
     openInterceptor,
     closeInterceptor,
     updateLocalEdgeData,
+    openNodeEditor,
+    closeNodeEditor,
     recommendConceptualNodes
   };
 }

--- a/src/composables/useEdgeInterceptor.ts
+++ b/src/composables/useEdgeInterceptor.ts
@@ -53,8 +53,6 @@ export function useEdgeInterceptor(explicitContext?: any) {
    * Finalizes the data structure and sends it to the store.
    */
   const confirmRelation = async () => {
-    if (!context.pendingConnection.value && context.interceptorAction.value == 'create') return;
-
     const newEdge: ConceptualEdge = {
       ...context.localEdgeData.value,
     };

--- a/src/composables/useEdgeInterceptor.ts
+++ b/src/composables/useEdgeInterceptor.ts
@@ -19,7 +19,7 @@ export function useEdgeInterceptor(explicitContext?: any) {
   /**
    * Internal Utility: getEdgeMidpoint
    * Calculates the center point between two nodes to place the interceptor UI.
-   * Directly used within startInterception.
+   * Directly used within startEdgeEdit.
    */
   const calculateMidpoint = (connection: Connection, nodes: Map<string, ConceptualNode>) => {
     // In Vue Flow, connection object provides source and target node info
@@ -41,7 +41,7 @@ export function useEdgeInterceptor(explicitContext?: any) {
    * Phase 1: INITIATE_CONNECTION
    * Called by @connect event in the canvas.
    */
-  const startInterception = (connection: Connection, nodes: Map<string, ConceptualNode>) => {
+  const startEdgeEdit = (connection: Connection, nodes: Map<string, ConceptualNode>) => {
     const midpoint = calculateMidpoint(connection, nodes);
 
     // Prevent immediate graph insertion; open the scoped contextual input form instead
@@ -82,7 +82,7 @@ export function useEdgeInterceptor(explicitContext?: any) {
   return {
     context,
     // Actions
-    startInterception,
+    startEdgeEdit,
     confirmRelation,
     cancelRelation,
     deleteRelation,

--- a/src/composables/useNodeInterceptor.ts
+++ b/src/composables/useNodeInterceptor.ts
@@ -37,10 +37,13 @@ export function useNodeInterceptor(explicitContext?: any) {
 
     if (!nodeId || !originalNode) return;
 
+    const nextStatus = originalNode.status === 'USER_DRAFT' ? 'LOCKED' : originalNode.status;
+
     const updatedNode: ConceptualNode = {
       ...originalNode,
       label: context.localNodeData.value.label,
-      userNotes: context.localNodeData.value.userNotes
+      userNotes: context.localNodeData.value.userNotes,
+      status: nextStatus
     };
 
     try {

--- a/src/composables/useNodeInterceptor.ts
+++ b/src/composables/useNodeInterceptor.ts
@@ -1,0 +1,68 @@
+/**
+ * @file useNodeInterceptor.ts
+ * @description Controller Module: Intercepts node modification events.
+ * Extracted from the component layer to ensure architectural parity with useEdgeInterceptor.
+ */
+import { inject } from 'vue';
+import type { ConceptualNode } from '@/interfaces/conceptual-map';
+import { ConceptualMapContextKey } from '@/constants/injection-keys';
+
+export function useNodeInterceptor(explicitContext?: any) {
+  const context = explicitContext || inject(ConceptualMapContextKey, null);
+
+  if (!context) {
+    throw new Error(
+      '[Architectural Violation] useNodeInterceptor must be invoked within the subtree of a <ConceptualMapCanvas>.'
+    );
+  }
+
+  /**
+   * Phase 1: INITIATE_NODE_EDIT
+   * Called by @node-double-click or custom edit button on the canvas.
+   */
+  const startNodeEdit = (nodeId: string) => {
+    const node = context.conceptualNodes.get(nodeId);
+    if (node) {
+      context.openNodeEditor(nodeId, node);
+    }
+  };
+
+  /**
+   * Phase 2: COMMIT_MUTATION_TO_STORE
+   * Aggregates the modified cache from localNodeData and flashes it back to persistent layout memory.
+   */
+  const confirmNodeEdit = async () => {
+    const nodeId = context.editingNodeId.value;
+    const originalNode = context.conceptualNodes.get(nodeId);
+
+    if (!nodeId || !originalNode) return;
+
+    const updatedNode: ConceptualNode = {
+      ...originalNode,
+      label: context.localNodeData.value.label,
+      userNotes: context.localNodeData.value.userNotes
+    };
+
+    try {
+      // Dispatch persistent edit action to backend & global store through base context
+      await context.updateConceptualMapNode(updatedNode, 'edit');
+
+      // Clean up UI states
+      context.closeNodeEditor();
+    } catch (error) {
+      console.error('[Node Interceptor Error] Failed to update node metadata:', error);
+    }
+  };
+
+  const cancelNodeEdit = () => {
+    context.closeNodeEditor();
+  };
+
+  return {
+    context,
+    // Actions exposed to UI Molecule
+    startNodeEdit,
+    confirmNodeEdit,
+    cancelNodeEdit
+  };
+}

--- a/src/interfaces/conceptual-map.ts
+++ b/src/interfaces/conceptual-map.ts
@@ -84,6 +84,7 @@ export interface ConceptualEdge {
   // --- Metadata & Identification ---
   label?: string;
   type: EdgeType; // Default: 'REF'
+  status?: EntityStatus;
 
   // --- Knowledge & Grounding (Empirical Layer) ---
   /** Logical justification for this link (Crucial for Agentic Audit) */

--- a/src/interfaces/core.ts
+++ b/src/interfaces/core.ts
@@ -18,6 +18,8 @@ export type EntityStatus =
   | 'ON_HOLD'       // Temporarily sidelined from the active map or focus
   | 'ARCHIVED';     // Removed from view but preserved in history
 
+export type EntityActionType = 'ACCEPT' | 'REJECT' | 'DELETE' | 'HOLD' | 'LOCK' | 'DRAFT';
+
 /** Hex or CSS color string for UI rendering. */
 export type ColorString = string;
 


### PR DESCRIPTION
This Pull Request represents a significant evolution of the Conceptual Map Canvas interaction architecture. It transitions the canvas from heavy modal overlays to contextual, lightweight, scale-invariant floating editors and unified quick-action toolbars. It also establishes support for `USER_DRAFT` and `AI_EXTRACTED` entity lifecycles for both nodes and edges.

---

### ## Key Changes

* **Canvas UI Architecture Overhaul**: Replaced the heavy, global `VModal` layout logic with contextual, scoped floating editors (`VNodeFloatingEditor`, `VEdgeFloatingEditor`) that align cleanly with the Vue Flow ecosystem.
* **Unified State Machine Action Components**: Introduced two foundational, reusable interaction layers—`VEntityStatusActionGroup` (for detailed form/state submittals) and `VEntityCanvasQuickActions` (a generic micro-toolbar for rapid single-click shortcuts).
* **UX Interaction Refinement**: Decoupled intense editing sessions from simple canvas selection streams. Detailed editors now trigger explicitly on clean actions (button clicks for nodes, label double-clicks for edges), while single-clicks are reserved for rapid quick actions.
* **Advanced Viewport Scale Invariance**: Implemented a dynamic zoom inverse scaling mechanism (`scale(${1 / zoom})`) using `useVueFlow` to ensure floating editors and toolbars render beautifully at a consistent 1:1 scale regardless of canvas zoom depth.
* **AI & Draft Lifecycle Support**: Implemented comprehensive status branching across elements, introducing pulsing interactive action pills ("Connect?") and glowing dashed animations specifically for AI-suggested graph data.

---

### ## Detailed Breakdown

#### ### Scoped Interceptor Pattern & Floating Editors

To prevent global state pollution and UI component flash, the canvas has migrated to an on-demand interceptor pattern.

* **Nodes**: Supported by `useNodeInterceptor` and the `@vue-flow/node-toolbar` dependency, editing panels are now contextually anchored directly above the targeted entity.
* **Edges**: Aligned the existing edge editing workflow with the same architectural pattern, replacing native canvas-level double-click listeners with targeted element-level events inside `VConceptualEdge`.

#### ### Unified Micro-Toolbars (`VEntityCanvasQuickActions`)

Instead of duplicating button groups across separate node and edge elements, a single unified micro-toolbar was engineered. This component normalizes graph mutation streams by intercepting rapid single-clicks. It handles status promotions (e.g., locking a node or accepting an AI suggestion) or rollbacks (e.g., rejecting an AI extraction or permanently deleting a draft link) seamlessly via an abstraction layer.

#### ### Context and API Synchronization

The `useConceptualMapContext` sandbox cache was extended to cleanly support low-frequency mutations. This includes full support for scale-adjusted spatial coordinates (`position` vectors divided by internal scaling factors) and connection state updates, safely dispatching data persistence requests down to the backend endpoints.

---

### ## Technical Decisions & Design Choices

* **Interaction Separation (Single vs. Double Click)**: *Why choose this approach?* In complex node-link diagrams, misclicks can lead to jarring UI states. By reserving **single-clicks** for rapid state verification toolbars and **double-clicks/button taps** for rich text editors, user workflow fatigue is drastically minimized.
* **CSS Transform Matrix vs. Position Adjustments**: For the scale-invariant UI, the inverse zoom logic was unified into a compound CSS `transform` statement (`translate(-50%, -50%) ... scale(${inverseScale})`). This allows the browser to perform calculations on the GPU, avoiding performance degradation during active panning and scaling.
* **Replacing Native Divs with `VBox**`: Shifted custom overlay codebases to use the design system's `VBox` atom to eliminate "magic values" and strictly enforce standardized layout padding and rounded border tokens.

---

### ## Migration Notes

* **Dependency Update**: This PR introduces `@vue-flow/node-toolbar`. Ensure an `npm install` or `yarn install` is executed downstream before starting the local development environment.
* **Canvas Component Cleanup**: Custom logic listening for `@edge-double-click` or `handleNodeDoubleClick` on the root `<VueFlow>` wrapper has been completely removed. Any downstream extension relying on global event bubbling for these specific triggers will need to migrate to the scoped interceptor pattern.

---

This change lays a highly modular foundation for our upcoming canvas multiplayer collaboration features and richer AI recommendation pipelines.

🚀 **Ready for review.** Feedback is particularly welcome on the responsiveness of the inverse zoom scaling across extreme map dimensions.