### PR TITLE
feat(project): implement project creation functionality

### DIFF
--- a/src/api/apiService.ts
+++ b/src/api/apiService.ts
@@ -169,6 +169,9 @@ export const apiService = {
       getProject: (): Promise<AxiosResponse<Project[]>> => {
         return apiClient.get(ProjectsEndpoints.base.getProject())
       },
+      createProject: (data: Project): Promise<AxiosResponse<Project>> => {
+        return apiClient.post(ProjectsEndpoints.base.createProject(), data);
+      },
       getProjectDetail: (projectId: ID): Promise<AxiosResponse<Project>> => {
         return apiClient.get(ProjectsEndpoints.base.getProjectDetail(projectId))
       },

--- a/src/api/endpoints/index.ts
+++ b/src/api/endpoints/index.ts
@@ -64,6 +64,8 @@ export const ProjectsEndpoints = {
   base: {
     getProject: () =>
       `${AURAFLUX_NEXUS_URL}/projects/`,
+    createProject: () =>
+      `${AURAFLUX_NEXUS_URL}/projects/`,
     getProjectDetail: (projectId: ID) =>
       `${AURAFLUX_NEXUS_URL}/projects/${projectId}/`,
     updateProjectDetail: (projectId: ID) =>

--- a/src/components/molecules/forms/VTagInput.vue
+++ b/src/components/molecules/forms/VTagInput.vue
@@ -1,0 +1,59 @@
+<template>
+  <VStack gap="sm">
+    <VCluster v-if="modelValue.length > 0" gap="xs" wrap>
+      <VEntityChip
+        v-for="(tag, index) in modelValue"
+        :key="index"
+        :label="tag"
+        @click="removeTag(index)"
+      />
+    </VCluster>
+
+    <VInput
+      v-model="inputValue"
+      :placeholder="placeholder"
+      :disabled="disabled"
+      @keydown="handleKeydown"
+      @blur="addTag"
+    />
+  </VStack>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import VInput from '@/components/atoms/forms/VInput.vue';
+import VStack from '@/components/atoms/layout/VStack.vue';
+import VCluster from '@/components/atoms/layout/VCluster.vue';
+import VEntityChip from '@/components/molecules/resources/VEntityChip.vue';
+
+const props = defineProps<{
+  modelValue: string[];
+  placeholder?: string;
+  disabled?: boolean;
+}>();
+
+const emit = defineEmits(['update:modelValue']);
+
+const inputValue = ref('');
+
+const addTag = () => {
+  const tag = inputValue.value.trim();
+  if (tag && !props.modelValue.includes(tag)) {
+    emit('update:modelValue', [...props.modelValue, tag]);
+  }
+  inputValue.value = '';
+};
+
+const handleKeydown = (e: KeyboardEvent) => {
+  if (e.key === 'Enter' || e.key === ',') {
+    e.preventDefault();
+    addTag();
+  }
+};
+
+const removeTag = (index: number) => {
+  const newTags = [...props.modelValue];
+  newTags.splice(index, 1);
+  emit('update:modelValue', newTags);
+};
+</script>

--- a/src/components/organisms/modals/ProjectModal.vue
+++ b/src/components/organisms/modals/ProjectModal.vue
@@ -1,0 +1,132 @@
+<template>
+  <VModal
+    :is-open="isOpen"
+    title="Create New Project"
+    size="md"
+    @close="handleClose"
+  >
+    <VForm @submit="submitForm">
+      <VStack gap="md">
+        <!-- Project Name -->
+        <VFormField
+          label="Project Name"
+          :required="true"
+          :error="errors.name"
+        >
+          <template #default="{ id }">
+            <VInput
+              :id="id"
+              v-model="localProject.name"
+              placeholder="e.g., Annual Budget Planning, Website Migration, Research Initiative"
+              :disabled="isSubmitting"
+            />
+          </template>
+        </VFormField>
+
+        <!-- Project Description -->
+        <VFormField
+          label="Description"
+          description="Provide a brief overview of your research goals."
+        >
+          <template #default="{ id }">
+            <VTextarea
+              :id="id"
+              v-model="localProject.description"
+              placeholder="What are you trying to find out?"
+              :disabled="isSubmitting"
+            />
+          </template>
+        </VFormField>
+        <VFormField
+          label="Tags"
+          description="Enter tags separated by commas (e.g., research, ai, quantum)"
+        >
+          <template #default="{ id }">
+            <VTagInput
+              :id="id"
+              v-model="localProject.tags"
+              placeholder="Press Enter to add a tag (e.g., Strategy, Migration, Research)"
+              :disabled="isSubmitting"
+            />
+          </template>
+        </VFormField>
+      </VStack>
+    </VForm>
+
+    <template #footer>
+      <VButton
+        variant="tertiary"
+        :disabled="isSubmitting"
+        @click="handleClose"
+      >
+        Cancel
+      </VButton>
+      <VButton
+        :loading="isSubmitting"
+        @click="submitForm"
+      >
+        Create Project
+      </VButton>
+    </template>
+  </VModal>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive } from 'vue';
+import { useProjectStore } from '@/stores/project';
+
+// Components
+import VModal from '@/components/molecules/feedback/VModal.vue';
+import VForm from '@/components/molecules/forms/VForm.vue';
+import VFormField from '@/components/molecules/forms/VFormField.vue';
+import VInput from '@/components/atoms/forms/VInput.vue';
+import VTextarea from '@/components/atoms/forms/VTextarea.vue';
+import VButton from '@/components/atoms/buttons/VButton.vue';
+import VStack from '@/components/atoms/layout/VStack.vue';
+import VTagInput from '@/components/molecules/forms/VTagInput.vue';
+
+import type { Project } from '@/interfaces/project';
+
+const props = defineProps<{ project: Project; isNew?: boolean; isOpen: boolean }>();
+const emit = defineEmits(['confirm', 'cancel']);
+
+const projectStore = useProjectStore();
+const isSubmitting = ref(false);
+
+const localProject = ref({ ...props.project });
+
+const errors = reactive({
+  name: ''
+});
+
+const handleClose = () => {
+  localProject.value.name = '';
+  localProject.value.description = '';
+  localProject.value.tags = [];
+  errors.name = '';
+  emit('cancel');
+};
+
+const submitForm = async () => {
+  if (!localProject.value.name.trim()) {
+    errors.name = 'Project name is required';
+    return;
+  }
+
+  errors.name = '';
+  isSubmitting.value = true;
+
+  try {
+    if (props.isNew) {
+      await projectStore.createProject(localProject.value);
+    }
+
+    emit('confirm');
+    handleClose();
+  } catch (e) {
+    console.error('Failed to create project', e);
+  } finally {
+    isSubmitting.value = false;
+  }
+};
+</script>

--- a/src/components/pages/ProjectPage.vue
+++ b/src/components/pages/ProjectPage.vue
@@ -10,17 +10,17 @@
         >
           <VProjectToolbar
             v-model="selectorState"
-            @create="isCreateModalOpen = true"
+            @create="isEditModalOpen = true"
           />
         </VBox>
 
         <VBox v-if="hasProjects || isFiltering" class="max-w-7xl mx-auto w-full px-6">
           <VGrid cols="1 sm:2 lg:3 xl:4" gap="lg">
             <VInteractivePlaceholder
-              label="Start New Research"
+              label="Start New Project"
               icon-name="Plus"
               class="h-48"
-              @click="isCreateModalOpen = true"
+              @click="isEditModalOpen = true"
             />
             <VProjectCard
               v-for="project in filteredProjects"
@@ -39,7 +39,16 @@
         />
       </VStack>
     </VBox>
+  </VBox>
 
+  <VBox tag="main" class="w-full min-h-screen bg-slate-50">
+    <ProjectModal
+      :is-open="isEditModalOpen"
+      :project="localProject"
+      :is-new="true"
+      @cancel="isEditModalOpen = false"
+      @confirm="handleProjectEditting"
+    />
   </VBox>
 </template>
 
@@ -52,17 +61,11 @@ import { useProjectStore } from '@/stores/project';
 import VBox from '@/components/atoms/layout/VBox.vue';
 import VStack from '@/components/atoms/layout/VStack.vue';
 import VGrid from '@/components/atoms/layout/VGrid.vue';
-import VTypography from '@/components/atoms/indicators/VTypography.vue';
-
-// Resource Molecules
 import VProjectToolbar from '@/components/molecules/resources/VProjectToolbar.vue';
 import VProjectCard from '@/components/molecules/resources/VProjectCard.vue';
 import VInteractivePlaceholder from '@/components/molecules/resources/VInteractivePlaceholder.vue';
-
-// Feedback Molecules
 import VEmptyState from '@/components/molecules/feedback/VEmptyState.vue';
-import VModal from '@/components/molecules/feedback/VModal.vue';
-import VButton from '@/components/atoms/buttons/VButton.vue';
+import ProjectModal from '@/components/organisms/modals/ProjectModal.vue';
 
 import type { ID } from '@/interfaces/core';
 import type { ISPStage, Project } from '@/interfaces/project';
@@ -73,7 +76,18 @@ const projectStore = useProjectStore();
 
 // --- State Management ---
 const isFiltering = ref(false);
-const isCreateModalOpen = ref(false);
+const isEditModalOpen = ref(false);
+
+const localProject = ref<Project>({
+  id: '',
+  name: '',
+  description: '',
+  status: 'LOCKED',
+  currentStage: 'CONSULTATION',
+  tags: [],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString()
+});
 
 const selectorState = ref<BaseSelectorState>({
   filter: 'LOCKED',
@@ -107,6 +121,20 @@ onMounted(async () => {
 
 const resetFilters = () => {
   selectorState.value.filter = 'ALL';
+};
+
+const handleProjectEditting = async () => {
+  localProject.value = {
+    id: '',
+    name: '',
+    description: '',
+    status: 'LOCKED',
+    currentStage: 'CONSULTATION',
+    tags: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+  }
+  projectStore.createProject(localProject.value);
 };
 
 const navigateToProject = (projectId: ID, currentStage: ISPStage) => {

--- a/src/interfaces/project.ts
+++ b/src/interfaces/project.ts
@@ -15,14 +15,3 @@ export interface Project {
   createdAt: DateTimeString;
   updatedAt: DateTimeString;
 }
-
-/**
- * Project State Decorator
- * A wrapper to add "Process Status" to any Knowledge or Canvas entity
- * without polluting the original Knowledge Interface.
- */
-export interface ProjectMetadata {
-  state: EntityStatus;
-  lastModifiedBy: ParticipantRole;
-  version: number;
-}

--- a/src/stores/project.ts
+++ b/src/stores/project.ts
@@ -36,6 +36,19 @@ export const useProjectStore = defineStore('project', () => {
   });
 
   // --- Actions (Functions) ---
+  async function createProject(project: Project) {
+    try {
+      let response = await apiService.projects.base.createProject(project);
+      if (response.data) {
+        projects.value.set(response.data.id, response.data);
+      } else {
+      console.log(response.data);
+      }
+    } catch (error) {
+      console.error('Failed to create a project:', error);
+    }
+  };
+
   async function loadProjects() {
     try {
       let response = await apiService.projects.base.getProject();
@@ -175,6 +188,7 @@ export const useProjectStore = defineStore('project', () => {
     projectName,
     isTyping,
     // Actions
+    createProject,
     loadConceptualNodes,
     loadExplorationPhaseData,
     loadProjects,


### PR DESCRIPTION
Add `createProject` API service and store action, create a new `VTagInput` molecule for tag management, and introduce `ProjectModal` for the project creation workflow in `ProjectPage`.

* Add `createProject` endpoint and service method.
* Implement `VTagInput` component for tag tokenization.
* Add `ProjectModal` for handling new project creation forms.
* Integrate `ProjectModal` into `ProjectPage` to replace manual creation logic.